### PR TITLE
Cache metadata (stat/dir)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(
   ${CMAKE_SOURCE_DIR}/src/iFuse.FS.cpp
   ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.Conn.cpp
   ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.Fd.cpp
+  ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.MetadataCache.cpp
   ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.RodsClientAPI.cpp
   ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.Util.cpp
   ${CMAKE_SOURCE_DIR}/src/iFuse.Lib.cpp

--- a/README.txt
+++ b/README.txt
@@ -76,9 +76,13 @@ Use irodsFsCtl for control
 
 1) Clear all metadata cache:
 ```
-irodsFsCtl.py yourMountPoint reset_cache
+irodsFsCtl.py reset_cache yourMountPoint
 ```
 
+2) Show established connections:
+```
+irodsFsCtl.py show_connections yourMountPoint
+```
 
 Helpful options
 ---------------

--- a/README.txt
+++ b/README.txt
@@ -61,14 +61,10 @@ work. Type in:
 and do the normal login.
 
 4) The irodsFs uses block-based file content transfer. Regardless of physical file 
-blocks of iRODS, the irodsFs divides the file content into fixed sized blocks 
-logically and requests content reads or writes to iRODS in the block level. 
-Hence, small reads or writes will be buffered and cached in memory temporarily. 
-Block size is set to 1MB by default. To change block size, you will need to 
-change the value of a definition of "IFUSE_BUFFER_CACHE_BLOCK_SIZE" 
-in iFuse.BufferedFS.hpp file. 
-To turn off this memory cache and buffered I/O, pass "-onocache" to command line 
-argument.
+blocks of iRODS, the irodsFs divides the file content into fixed-size blocks 
+logically and requests content reads/writes to iRODS in the block level. 
+Hence, small reads/writes will be buffered and cached in memory temporarily.
+Block size is set to 1MB by default.
 
 5) Mount the home collection to the local directory by typing in:
 ./irodsFs /usr/tmp/fmount
@@ -99,4 +95,3 @@ WARNING
 such as iput, irm, icp, etc to change the content of the collection because
 the FUSE implementation seems to cache the attributes of the contents of
 the collection.  
-

--- a/README.txt
+++ b/README.txt
@@ -28,18 +28,6 @@ the UNIX mount directory to control access to the mounted data.
 Building irods FUSE:
 --------------------
 
-a) Edit the config/config.mk file:
-
-1) Uncomment the line:
-    # IRODS_FS = 1
-
-2) set fuseHomeDir to the directory where the fuse library and include
-files are installed. e.g.,
-
-    fuseHomeDir=/usr/local/fuse
-
-b) Making irods Fuse:
-
 Type in:
 
 cd clients/fuse
@@ -54,19 +42,13 @@ Running irods Fuse:
 
     mkdir /usr/tmp/fmount
 
-3) Setup the iRODS client env (~/irods/irods_environment.json) so that iCommands will
-work. Type in:
+3) Setup the iRODS client env (~/irods/irods_environment.json) so that iCommands
+will work. Type in:
     iinit
 
 and do the normal login.
 
-4) The irodsFs uses block-based file content transfer. Regardless of physical file 
-blocks of iRODS, the irodsFs divides the file content into fixed-size blocks 
-logically and requests content reads/writes to iRODS in the block level. 
-Hence, small reads/writes will be buffered and cached in memory temporarily.
-Block size is set to 1MB by default.
-
-5) Mount the home collection to the local directory by typing in:
+4) Mount the home collection to the local directory by typing in:
 ./irodsFs /usr/tmp/fmount
 
 The user's home collection is now mounted. The iRODS files and sub-collections 
@@ -75,6 +57,7 @@ through the /usr/tmp/fmount directory.
 
 Run irodsFs in debug mode
 -------------------------
+
 To run irodsFs in debug mode:
 
 1) set the env variable irodsLogLevel to 4, e.g. in csh:
@@ -83,15 +66,68 @@ setenv irodsLogLevel 4
 
 2) run irodsFs in debug mode, e.g.
 
-irodsFs yourMountPoint -d
+irodsFs -d yourMountPoint
 
 It should print out a lot of debugging info.
+
+
+Use irodsFsCtl for control
+--------------------------
+
+1) Clear all metadata cache:
+```
+irodsFsCtl.py yourMountPoint reset_cache
+```
+
+
+Helpful options
+---------------
+
+1) Enabling/disabling features
+- `-onocache`: Disable all caching features (Buffered IO, Preload, Metadata 
+   Cache)
+- `-onopreload`: Disable Preload feature that pre-fetches file blocks in 
+   advance. By default, the preload is turned on.
+- `-onocachemetadata`: Disable metadata caching feature. By default, the 
+   metadata cacheing is turned on.
+- `-oconnreuse`: Set to reuse network connections for performance. This may 
+   provide inconsistent metadata with mysql-backed iCAT. By default, connections
+   are not reused.
+
+2) Other configurations
+- `-omaxconn`: Set max number of network connection to be established at the 
+   same time. By default, this is set to 10.
+- `-oblocksize`: Set block size at data transfer. All transfer is made in a 
+   block-level for performance. By default, this is set to 1048576(1MB).
+- `-oconntimeout`: Set timeout of a network connection. After the timeout, idle 
+   connections will be automatically closed. By default, this is set to 300
+   (5 minutes).
+- `-oconnkeepalive`: Set intervals of keepalive requests. For every keepalive 
+   intervals, keepalive message is sent to iCAT to keep network connections 
+   live. By default, this is set to 180(3 minutes).
+- `-oconncheckinterval`: Set intervals of connection timeout check. For every 
+   check intervals, all connections established are checked to figure out if 
+   they are timed-out. By default, this is set to 10(10 seconds).
+- `-oapitimeout`: Set timeout of iRODS client API calls. If an API call does not
+   respond before the timeout, the API call and the network connection 
+   associated with are killed. By default, this is set to 90(90 seconds).
+- `-opreloadblocks`: Set the number of blocks pre-fetched. By default, this is 
+   set to 3 (next 3 blocks in advance).
+- `-ometadatacachetimeout`: Set timeout of a metadata cache. Metadata caches are
+   invalidated after the timeout. By default, this is set to 180(3 minutes).
+
+
+For example, following command will 1) reuse connections, 2) prefetch next 
+5 blocks and 3) set timeout of metadata cache to 1 hour.
+```
+irodsFs -oconnreuse -opreloadblocks 5 -ometadatacachetimeout 3600 yourMountPoint
+```
 
 
 WARNING
 -------
 
-1) When a collection is mounted using irodsFs, users should not use iCommands
-such as iput, irm, icp, etc to change the content of the collection because
-the FUSE implementation seems to cache the attributes of the contents of
-the collection.  
+1) When a collection is mounted using irodsFs, uses of iCommands
+such as iput, irm, icp, etc that change the content of the collection should be 
+avoided because the FUSE implementation caches the attributes of the contents of
+the collection.

--- a/bin/irodsFsCtl.py
+++ b/bin/irodsFsCtl.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+
+import os
+import os.path
+import sys
+import fcntl
+
+def reset_cache(mount_path):
+    fd = os.open(mount_path, os.O_DIRECTORY)
+    status = fcntl.ioctl(fd, 0xEE00)
+    if status != 0:
+        print >> sys.stderr, "failed to reset cache"
+    os.close(fd)
+
+def ioctl(mount_path, command, oargs):
+    if command == None:
+        print >> sys.stderr, "No command is given"
+        
+    if command.lower() in ["reset_cache"]:
+        reset_cache(mount_path)
+    else:
+        print >> sys.stderr, "Unrecognized command: %s" % (command)
+
+def main(argv):
+    if len(argv) < 2:
+        print "command : ./irodsFsCtl.py <MOUNT_PATH> <COMMAND> <Optional_Args...>"
+    else:
+        mount_path = argv[0]
+        command = argv[1]
+        oargs = argv[2:]
+        
+        ioctl(mount_path, command, oargs)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/bin/irodsFsCtl.py
+++ b/bin/irodsFsCtl.py
@@ -1,35 +1,124 @@
 #! /usr/bin/env python
 
+# This code is written by Illyoung Choi (iychoi@email.arizona.edu)
+# funded by iPlantCollaborative (www.iplantcollaborative.org).
+
 import os
 import os.path
 import sys
 import fcntl
+import array
+
+IOCTL_APP_NUMBER = 0xEE
+IFUSEIOC_RESET_METADATA_CACHE = 0
+IFUSEIOC_SHOW_CONNECTIONS = 1
+
+
+_IOC_NRBITS = 8
+_IOC_TYPEBITS = 8
+_IOC_SIZEBITS = 14
+_IOC_DIRBITS = 2
+
+_IOC_NRMASK = (1 << _IOC_NRBITS) - 1
+_IOC_TYPEMASK = (1 << _IOC_TYPEBITS) - 1
+_IOC_SIZEMASK = (1 << _IOC_SIZEBITS) - 1
+_IOC_DIRMASK = (1 << _IOC_DIRBITS) - 1
+
+_IOC_NRSHIFT = 0
+_IOC_TYPESHIFT = _IOC_NRSHIFT + _IOC_NRBITS
+_IOC_SIZESHIFT = _IOC_TYPESHIFT + _IOC_TYPEBITS
+_IOC_DIRSHIFT = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+_IOC_NONE = 0
+_IOC_WRITE = 1
+_IOC_READ = 2
+
+def _IOC(dir, type, nr, size):
+    return (dir  << _IOC_DIRSHIFT) | (type << _IOC_TYPESHIFT) | (nr << _IOC_NRSHIFT) | (size << _IOC_SIZESHIFT)
+
+def _IO(type, nr):
+    return _IOC(_IOC_NONE, type, nr, 0)
+    
+def _IOR(type, nr, size):
+    return _IOC(_IOC_READ, type, nr, size)
+
+def _IOW(type, nr, size):
+    return _IOC(_IOC_WRITE, type, nr, size)
+    
+def _IOWR(type, nr, size):
+    return _IOC(_IOC_READ | _IOC_WRITE, type, nr, size)
+
+
 
 def reset_cache(mount_path):
+    print "reset cache: %s" % (mount_path)
+    
     fd = os.open(mount_path, os.O_DIRECTORY)
-    status = fcntl.ioctl(fd, 0xEE00)
+    status = fcntl.ioctl(fd, _IO(IOCTL_APP_NUMBER, IFUSEIOC_RESET_METADATA_CACHE))
     if status != 0:
         print >> sys.stderr, "failed to reset cache"
+    else:
+        print "Done!"
+    os.close(fd)
+    
+def show_connections(mount_path):
+    print "show connections: %s" % (mount_path)
+    
+    fd = os.open(mount_path, os.O_DIRECTORY)
+    buf = array.array('i', [0,0,0,0,0])
+    status = fcntl.ioctl(fd, _IOR(IOCTL_APP_NUMBER, IFUSEIOC_SHOW_CONNECTIONS, 20), buf, 1)
+    if status != 0:
+        print >> sys.stderr, "failed to show connections"
+    else:
+        inuseShortOpConn = buf[0]
+        inuseConn = buf[1]
+        inuseOnetimeuseConn = buf[2]
+        freeShortopConn = buf[3]
+        freeConn = buf[4]
+        
+        print "In-Use ShortOp Conn: %d" % inuseShortOpConn
+        print "In-Use Conn: %d" % inuseConn
+        print "In-Use OneTimeUse Conn: %d" % inuseOnetimeuseConn
+        print "Free ShortOp Conn: %d" % freeShortopConn
+        print "Free Conn: %d" % freeConn
+        print "Done!"
     os.close(fd)
 
-def ioctl(mount_path, command, oargs):
-    if command == None:
+COMMANDS = {
+    "reset_cache": reset_cache,
+    "show_connections": show_connections,
+}
+
+COMMANDS_DESCS = {
+    "reset_cache": "invalidate all caches",
+    "show_connections": "show all established connections"
+}
+
+def ioctl(command, mount_path, oargs):
+    if command is None:
         print >> sys.stderr, "No command is given"
-        
-    if command.lower() in ["reset_cache"]:
-        reset_cache(mount_path)
+    
+    command = command.lower()
+    mount_path = os.path.abspath(mount_path)
+    
+    if command in COMMANDS:
+        COMMANDS[command](mount_path)
     else:
         print >> sys.stderr, "Unrecognized command: %s" % (command)
 
 def main(argv):
     if len(argv) < 2:
-        print "command : ./irodsFsCtl.py <MOUNT_PATH> <COMMAND> <Optional_Args...>"
+        print "command : ./irodsFsCtl.py <COMMAND> <IRODSFS_MOUNT_PATH> <Optional_Args...>"
+        print ""
+        print "Available Commands"
+        for k in COMMANDS.keys():
+            print "%s: %s" % (k, COMMANDS_DESCS[k])
     else:
-        mount_path = argv[0]
-        command = argv[1]
+        command = argv[0]
+        mount_path = argv[1]
         oargs = argv[2:]
         
-        ioctl(mount_path, command, oargs)
+        ioctl(command, mount_path, oargs)
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/include/iFuse.BufferedFS.hpp
+++ b/include/iFuse.BufferedFS.hpp
@@ -3,7 +3,7 @@
 /*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_BUFFEREDFS_HPP
-#define	IFUSE_BUFFEREDFS_HPP
+#define IFUSE_BUFFEREDFS_HPP
 
 #include <pthread.h>
 #include "iFuse.Lib.Fd.hpp"
@@ -35,4 +35,3 @@ int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
 int iFuseBufferedFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t size);
 
 #endif	/* IFUSE_BUFFEREDFS_HPP */
-

--- a/include/iFuse.FS.hpp
+++ b/include/iFuse.FS.hpp
@@ -3,8 +3,9 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_FS_HPP
-#define	IFUSE_FS_HPP
+#define IFUSE_FS_HPP
 
+#include <sys/stat.h>
 #include "iFuse.Lib.hpp"
 #include "iFuse.Lib.Fd.hpp"
 
@@ -34,6 +35,4 @@ int iFuseFsRename(const char *iRodsFromPath, const char *iRodsToPath);
 int iFuseFsTruncate(const char *iRodsPath, off_t size);
 int iFuseFsChmod(const char *iRodsPath, mode_t mode);
 
-
-#endif	/* IFUSE_BASEOPS_HPP */
-
+#endif	/* IFUSE_FS_HPP */

--- a/include/iFuse.FS.hpp
+++ b/include/iFuse.FS.hpp
@@ -6,13 +6,21 @@
 #define IFUSE_FS_HPP
 
 #include <sys/stat.h>
+#include <sys/uio.h>
+#include <sys/ioctl.h>
 #include "iFuse.Lib.hpp"
 #include "iFuse.Lib.Fd.hpp"
+#include "iFuse.Lib.Conn.hpp"
 
 #define DEF_FILE_MODE	0660
 #define DEF_DIR_MODE	0770
 #define FILE_BLOCK_SIZE	512
 #define DIR_SIZE        4096
+
+#define IOCTL_APP_NUMBER 0xEE
+
+#define IFUSEIOC_RESET_METADATA_CACHE _IO(IOCTL_APP_NUMBER, 0)
+#define IFUSEIOC_SHOW_CONNECTIONS _IOR(IOCTL_APP_NUMBER, 1, iFuseFsConnReport_t)
 
 typedef int (*iFuseDirFiller) (void *buf, const char *name, const struct stat *stbuf, off_t off);
 
@@ -34,5 +42,7 @@ int iFuseFsRemoveDir(const char *iRodsPath);
 int iFuseFsRename(const char *iRodsFromPath, const char *iRodsToPath);
 int iFuseFsTruncate(const char *iRodsPath, off_t size);
 int iFuseFsChmod(const char *iRodsPath, mode_t mode);
+int iFuseFsIoctl(const char *iRodsPath, int cmd, void *arg, struct fuse_file_info *fi, unsigned int flags, void *data);
+int iFuseFsCacheDir(const char *iRodsPath);
 
 #endif	/* IFUSE_FS_HPP */

--- a/include/iFuse.Lib.Conn.hpp
+++ b/include/iFuse.Lib.Conn.hpp
@@ -40,6 +40,7 @@ typedef struct IFuseConn {
  * - iFuseConnDestroy
  */
 
+int iFuseConnTest();
 void iFuseConnInit();
 void iFuseConnDestroy();
 int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType);

--- a/include/iFuse.Lib.Conn.hpp
+++ b/include/iFuse.Lib.Conn.hpp
@@ -23,12 +23,20 @@ typedef struct IFuseConn {
     unsigned long connId;
     int type;
     rcComm_t *conn;
-    time_t actTime;
-    time_t lastKeepAliveTime;
+    time_t lastActTime;
+    time_t lastUseTime;
     int inuseCnt;
-    pthread_mutexattr_t lockAttr;
-    pthread_mutex_t lock;
+    pthread_rwlockattr_t lockAttr;
+    pthread_rwlock_t lock;
 } iFuseConn_t;
+
+typedef struct IFuseFsConnReport {
+    int inuseShortOpConn;
+    int inuseConn;
+    int inuseOnetimeuseConn;
+    int freeShortopConn;
+    int freeConn;
+} iFuseFsConnReport_t;
 
 /*
  * Usage pattern
@@ -44,8 +52,10 @@ typedef struct IFuseConn {
 int iFuseConnTest();
 void iFuseConnInit();
 void iFuseConnDestroy();
+void iFuseConnReport(iFuseFsConnReport_t *report);
 int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType);
 int iFuseConnUnuse(iFuseConn_t *iFuseConn);
+void iFuseConnUpdateLastActTime(iFuseConn_t *iFuseConn, bool lock);
 int iFuseConnReconnect(iFuseConn_t *iFuseConn);
 void iFuseConnLock(iFuseConn_t *iFuseConn);
 void iFuseConnUnlock(iFuseConn_t *iFuseConn);

--- a/include/iFuse.Lib.Conn.hpp
+++ b/include/iFuse.Lib.Conn.hpp
@@ -3,9 +3,10 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_CONN_HPP
-#define	IFUSE_LIB_CONN_HPP
+#define IFUSE_LIB_CONN_HPP
 
 #include <pthread.h>
+#include <time.h>
 #include "rodsClient.h"
 
 #define IFUSE_MAX_NUM_CONN	10
@@ -14,9 +15,9 @@
 #define IFUSE_CONN_TYPE_FOR_SHORTOP      1
 #define IFUSE_CONN_TYPE_FOR_ONETIMEUSE   2
 
-#define IFUSE_FREE_CONN_CHECK_PERIOD    10
-#define IFUSE_FREE_CONN_TIMEOUT_SEC     (60*5)
-#define IFUSE_FREE_CONN_KEEPALIVE_SEC   (60*3)
+#define IFUSE_FREE_CONN_CHECK_INTERVAL_SEC  10
+#define IFUSE_FREE_CONN_TIMEOUT_SEC         (60*5)
+#define IFUSE_FREE_CONN_KEEPALIVE_SEC       (60*3)
 
 typedef struct IFuseConn {
     unsigned long connId;

--- a/include/iFuse.Lib.Fd.hpp
+++ b/include/iFuse.Lib.Fd.hpp
@@ -3,7 +3,7 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_FD_HPP
-#define	IFUSE_LIB_FD_HPP
+#define IFUSE_LIB_FD_HPP
 
 #include <pthread.h>
 #include "iFuse.Lib.Conn.hpp"
@@ -25,6 +25,8 @@ typedef struct IFuseDir {
     collHandle_t *handle;
     iFuseConn_t *conn;
     char *iRodsPath;
+    char *cachedEntries;
+    unsigned int cachedEntryBufferLen;
     pthread_mutexattr_t lockAttr;
     pthread_mutex_t lock;
 } iFuseDir_t;
@@ -36,6 +38,7 @@ void iFuseDirDestroy();
 int iFuseFdOpen(iFuseFd_t **iFuseFd, iFuseConn_t *iFuseConn, const char* iRodsPath, int openFlag);
 int iFuseFdReopen(iFuseFd_t *iFuseFd);
 int iFuseDirOpen(iFuseDir_t **iFuseDir, iFuseConn_t *iFuseConn, const char* iRodsPath);
+int iFuseDirOpenWithCache(iFuseDir_t **iFuseDir, const char* iRodsPath, const char* cachedEntries, unsigned int entryBufferLen);
 int iFuseFdClose(iFuseFd_t *iFuseFd);
 int iFuseDirClose(iFuseDir_t *iFuseDir);
 void iFuseFdLock(iFuseFd_t *iFuseFd);
@@ -44,4 +47,3 @@ void iFuseFdUnlock(iFuseFd_t *iFuseFd);
 void iFuseDirUnlock(iFuseDir_t *iFuseDir);
 
 #endif	/* IFUSE_LIB_FD_HPP */
-

--- a/include/iFuse.Lib.Fd.hpp
+++ b/include/iFuse.Lib.Fd.hpp
@@ -16,8 +16,8 @@ typedef struct IFuseFd {
     char *iRodsPath;
     int openFlag;
     off_t lastFilePointer;
-    pthread_mutexattr_t lockAttr;
-    pthread_mutex_t lock;
+    pthread_rwlockattr_t lockAttr;
+    pthread_rwlock_t lock;
 } iFuseFd_t;
 
 typedef struct IFuseDir {
@@ -27,14 +27,12 @@ typedef struct IFuseDir {
     char *iRodsPath;
     char *cachedEntries;
     unsigned int cachedEntryBufferLen;
-    pthread_mutexattr_t lockAttr;
-    pthread_mutex_t lock;
+    pthread_rwlockattr_t lockAttr;
+    pthread_rwlock_t lock;
 } iFuseDir_t;
 
 void iFuseFdInit();
-void iFuseDirInit();
 void iFuseFdDestroy();
-void iFuseDirDestroy();
 int iFuseFdOpen(iFuseFd_t **iFuseFd, iFuseConn_t *iFuseConn, const char* iRodsPath, int openFlag);
 int iFuseFdReopen(iFuseFd_t *iFuseFd);
 int iFuseDirOpen(iFuseDir_t **iFuseDir, iFuseConn_t *iFuseConn, const char* iRodsPath);

--- a/include/iFuse.Lib.MetadataCache.hpp
+++ b/include/iFuse.Lib.MetadataCache.hpp
@@ -1,0 +1,42 @@
+/*** Copyright (c), The Regents of the University of California            ***
+ *** For more information please refer to files in the COPYRIGHT directory ***/
+/*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
+ *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+#ifndef IFUSE_LIB_METADATACACHE_HPP
+#define IFUSE_LIB_METADATACACHE_HPP
+
+#include <sys/stat.h>
+#include <list>
+#include <time.h>
+
+#define IFUSE_METADATA_CACHE_TIMEOUT_SEC           (30)
+
+typedef struct IFuseStatCache {
+    char *iRodsPath;
+    struct stat *stbuf;
+    time_t timestamp;
+} iFuseStatCache_t;
+
+typedef struct IFuseDirCache {
+    char *iRodsPath;
+    std::list<char*> *entries;
+    time_t timestamp;
+} iFuseDirCache_t;
+
+void iFuseMetadataCacheInit();
+void iFuseMetadataCacheDestroy();
+int iFuseMetadataCacheClearExpiredStat(bool force);
+int iFuseMetadataCacheClearExpiredDir(bool force);
+int iFuseMetadataCachePutStat(const char *iRodsPath, const struct stat *stbuf);
+int iFuseMetadataCachePutStat2(const char *iRodsDirPath, const char *iRodsFilename, const struct stat *stbuf);
+int iFuseMetadataCacheAddDirEntry(const char *iRodsPath, const char *iRodsFilename);
+int iFuseMetadataCacheAddDirEntryIfFresh(const char *iRodsPath, const char *iRodsFilename);
+int iFuseMetadataCacheAddDirEntryIfFresh2(const char *iRodsPath);
+int iFuseMetadataCacheGetStat(const char *iRodsPath, struct stat *stbuf);
+int iFuseMetadataCacheGetDirEntry(const char *iRodsPath, char **entries, unsigned int *bufferLen);
+int iFuseMetadataCacheRemoveStat(const char *iRodsPath);
+int iFuseMetadataCacheRemoveDir(const char *iRodsPath);
+int iFuseMetadataCacheRemoveDirEntry(const char *iRodsPath, const char *iRodsFilename);
+int iFuseMetadataCacheRemoveDirEntry2(const char *iRodsPath);
+
+#endif	/* IFUSE_LIB_METADATACACHE_HPP */

--- a/include/iFuse.Lib.MetadataCache.hpp
+++ b/include/iFuse.Lib.MetadataCache.hpp
@@ -1,7 +1,5 @@
-/*** Copyright (c), The Regents of the University of California            ***
- *** For more information please refer to files in the COPYRIGHT directory ***/
-/*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
- *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+/*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)    ***
+ *** funded by iPlantCollaborative (www.iplantcollaborative.org).        ***/
 #ifndef IFUSE_LIB_METADATACACHE_HPP
 #define IFUSE_LIB_METADATACACHE_HPP
 
@@ -9,7 +7,7 @@
 #include <list>
 #include <time.h>
 
-#define IFUSE_METADATA_CACHE_TIMEOUT_SEC           (30)
+#define IFUSE_METADATA_CACHE_TIMEOUT_SEC           (3*60)
 
 typedef struct IFuseStatCache {
     char *iRodsPath;
@@ -25,6 +23,7 @@ typedef struct IFuseDirCache {
 
 void iFuseMetadataCacheInit();
 void iFuseMetadataCacheDestroy();
+void iFuseMetadataCacheClear();
 int iFuseMetadataCacheClearExpiredStat(bool force);
 int iFuseMetadataCacheClearExpiredDir(bool force);
 int iFuseMetadataCachePutStat(const char *iRodsPath, const struct stat *stbuf);
@@ -34,6 +33,7 @@ int iFuseMetadataCacheAddDirEntryIfFresh(const char *iRodsPath, const char *iRod
 int iFuseMetadataCacheAddDirEntryIfFresh2(const char *iRodsPath);
 int iFuseMetadataCacheGetStat(const char *iRodsPath, struct stat *stbuf);
 int iFuseMetadataCacheGetDirEntry(const char *iRodsPath, char **entries, unsigned int *bufferLen);
+int iFuseMetadataCacheCheckExistanceOfDirEntry(const char *iRodsPath);
 int iFuseMetadataCacheRemoveStat(const char *iRodsPath);
 int iFuseMetadataCacheRemoveDir(const char *iRodsPath);
 int iFuseMetadataCacheRemoveDirEntry(const char *iRodsPath, const char *iRodsFilename);

--- a/include/iFuse.Lib.RodsClientAPI.hpp
+++ b/include/iFuse.Lib.RodsClientAPI.hpp
@@ -3,7 +3,7 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_RODSCLIENTAPI_HPP
-#define	IFUSE_LIB_RODSCLIENTAPI_HPP
+#define IFUSE_LIB_RODSCLIENTAPI_HPP
 
 #include <pthread.h>
 #include "rodsClient.h"
@@ -80,4 +80,3 @@ void iFuseRodsClientLogToFile(int level, const char *formatStr, ...);
 void iFuseRodsClientLogErrorToFile(int level, int errCode, char *formatStr, ...);
 
 #endif	/* IFUSE_LIB_RODSCLIENTAPI_HPP */
-

--- a/include/iFuse.Lib.RodsClientAPI.hpp
+++ b/include/iFuse.Lib.RodsClientAPI.hpp
@@ -9,9 +9,9 @@
 #include "rodsClient.h"
 #include "iFuse.Lib.Util.hpp"
 
-#define IFUSE_RODSCLIENTAPI_TIMEOUT_SEC     (30)
+#define IFUSE_RODSCLIENTAPI_TIMEOUT_SEC     (90)
 
-//#define IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
+#define IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
 //#define IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
 #define IFUSE_RODSCLIENTAPI_LOG_OUT_FILE_PATH   "/tmp/irods_debug.out"
 
@@ -22,7 +22,7 @@ int iFuseRodsClientReadMsgError(int status);
 
 #ifdef IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
 #   define iFuseRodsClientLogBase       iFuseRodsClientLogToFile
-#   define iFuseRodsClientLogErrorBase  iFuseRodsClientLogErrorToFile 
+#   define iFuseRodsClientLogErrorBase  iFuseRodsClientLogErrorToFile
 #else
 #   define iFuseRodsClientLogBase       rodsLog
 #   define iFuseRodsClientLogErrorBase  rodsLogError

--- a/include/iFuse.Lib.RodsClientAPI.hpp
+++ b/include/iFuse.Lib.RodsClientAPI.hpp
@@ -11,47 +11,11 @@
 
 #define IFUSE_RODSCLIENTAPI_TIMEOUT_SEC     (90)
 
-#define IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
-//#define IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
-#define IFUSE_RODSCLIENTAPI_LOG_OUT_FILE_PATH   "/tmp/irods_debug.out"
 
 void iFuseRodsClientInit();
 void iFuseRodsClientDestroy();
 
 int iFuseRodsClientReadMsgError(int status);
-
-#ifdef IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
-#   define iFuseRodsClientLogBase       iFuseRodsClientLogToFile
-#   define iFuseRodsClientLogErrorBase  iFuseRodsClientLogErrorToFile
-#else
-#   define iFuseRodsClientLogBase       rodsLog
-#   define iFuseRodsClientLogErrorBase  rodsLogError
-#endif // IFUSE_RODSCLIENTAPI_LOG_OUT_TO_FILE
-
-
-#ifdef IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
-#   define iFuseRodsClientLog \
-    { \
-    char logtimes[100]; \
-    iFuseLibGetStrCurrentTime(logtimes); \
-    iFuseRodsClientLogBase(LOG_DEBUG, "%s", logtimes); \
-    } \
-    iFuseRodsClientLogBase
-#else
-#   define iFuseRodsClientLog   iFuseRodsClientLogBase
-#endif // IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
-
-#ifdef IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
-#   define iFuseRodsClientLogError \
-    { \
-    char logtimes[100]; \
-    iFuseLibGetStrCurrentTime(logtimes); \
-    iFuseRodsClientLogBase(LOG_DEBUG, "%s", logtimes); \
-    } \
-    iFuseRodsClientLogErrorBase
-#else
-#   define iFuseRodsClientLogError  iFuseRodsClientLogErrorBase
-#endif // IFUSE_RODSCLIENTAPI_LOG_PRINT_TIME
 
 rcComm_t *iFuseRodsClientConnect(const char *rodsHost, int rodsPort, const char *userName, const char *rodsZone, int reconnFlag, rErrMsg_t *errMsg);
 int iFuseRodsClientLogin(rcComm_t *conn);
@@ -75,8 +39,5 @@ int iFuseRodsClientRmColl(rcComm_t *conn, collInp_t *rmCollInp, int vFlag);
 int iFuseRodsClientDataObjRename(rcComm_t *conn, dataObjCopyInp_t *dataObjRenameInp);
 int iFuseRodsClientDataObjTruncate(rcComm_t *conn, dataObjInp_t *dataObjInp);
 int iFuseRodsClientModDataObjMeta(rcComm_t *conn, modDataObjMeta_t *modDataObjMetaInp);
-
-void iFuseRodsClientLogToFile(int level, const char *formatStr, ...);
-void iFuseRodsClientLogErrorToFile(int level, int errCode, char *formatStr, ...);
 
 #endif	/* IFUSE_LIB_RODSCLIENTAPI_HPP */

--- a/include/iFuse.Lib.Util.hpp
+++ b/include/iFuse.Lib.Util.hpp
@@ -3,7 +3,7 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_UTIL_HPP
-#define	IFUSE_LIB_UTIL_HPP
+#define IFUSE_LIB_UTIL_HPP
 
 #include <time.h>
 
@@ -13,7 +13,9 @@
 
 time_t iFuseLibGetCurrentTime();
 void iFuseLibGetStrCurrentTime(char *buff);
-double IFuseLibDiffTimeSec(time_t end, time_t beginning);
+double iFuseLibDiffTimeSec(time_t end, time_t beginning);
+int iFuseLibSplitPath(const char *srcPath, char *dir, unsigned int maxDirLen, char *file, unsigned int maxFileLen);
+int iFuseLibJoinPath(const char *dir, const char *file, char *destPath, unsigned int maxDestPathLen);
+int iFuseLibGetFilename(const char *srcPath, char *file, unsigned int maxFileLen);
 
 #endif	/* IFUSE_LIB_UTIL_HPP */
-

--- a/include/iFuse.Lib.Util.hpp
+++ b/include/iFuse.Lib.Util.hpp
@@ -1,21 +1,74 @@
 /*** Copyright (c), The Regents of the University of California            ***
  *** For more information please refer to files in the COPYRIGHT directory ***/
-/*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
+/*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_UTIL_HPP
 #define IFUSE_LIB_UTIL_HPP
 
 #include <time.h>
+#include <pthread.h>
 
 #ifndef UNUSED
 #define UNUSED(expr) (void)(expr)
 #endif
 
+#define IFUSE_LIB_LOG_PRINT_TIME
+//#define IFUSE_LIB_LOG_OUT_TO_FILE
+#define IFUSE_LIB_LOG_OUT_FILE_PATH   "/tmp/irods_debug.out"
+
+#ifdef IFUSE_LIB_LOG_OUT_TO_FILE
+#define iFuseLibLogBase(level, formatStr, ...)   \
+    iFuseLibLogLock(); \
+    iFuseLibLogToFile(level, formatStr, ## __VA_ARGS__); \
+    iFuseLibLogUnlock()
+#define iFuseLibLogErrorBase(level, errCode, formatStr, ...)   \
+    iFuseLibLogLock(); \
+    iFuseLibLogErrorToFile(level, errCode, formatStr, ## __VA_ARGS__); \
+    iFuseLibLogUnlock()
+#else
+#   define iFuseLibLogBase       rodsLog
+#   define iFuseLibLogErrorBase  rodsLogError
+#endif
+
+#ifdef IFUSE_LIB_LOG_PRINT_TIME
+#   define iFuseLibLog \
+    { \
+    char logtimes[100]; \
+    iFuseLibGetStrCurrentTime(logtimes); \
+    iFuseLibLogBase(LOG_DEBUG, "%s", logtimes); \
+    } \
+    iFuseLibLogBase
+#else
+#   define iFuseLibLog   iFuseLibLogBase
+#endif
+
+#ifdef IFUSE_LIB_LOG_PRINT_TIME
+#   define iFuseLibLogError \
+    { \
+    char logtimes[100]; \
+    iFuseLibGetStrCurrentTime(logtimes); \
+    iFuseLibLogBase(LOG_DEBUG, "%s", logtimes); \
+    } \
+    iFuseLibLogErrorBase
+#else
+#   define iFuseLibLogError  iFuseLibLogErrorBase
+#endif
+
+void iFuseUtilInit();
+void iFuseUtilDestroy();
+
+int iFuseUtilStricmp (const char *s1, const char *s2);
 time_t iFuseLibGetCurrentTime();
 void iFuseLibGetStrCurrentTime(char *buff);
+void iFuseLibGetStrTime(time_t time, char *buff);
 double iFuseLibDiffTimeSec(time_t end, time_t beginning);
 int iFuseLibSplitPath(const char *srcPath, char *dir, unsigned int maxDirLen, char *file, unsigned int maxFileLen);
 int iFuseLibJoinPath(const char *dir, const char *file, char *destPath, unsigned int maxDestPathLen);
 int iFuseLibGetFilename(const char *srcPath, char *file, unsigned int maxFileLen);
+
+void iFuseLibLogToFile(int level, const char *formatStr, ...);
+void iFuseLibLogErrorToFile(int level, int errCode, char *formatStr, ...);
+void iFuseLibLogLock();
+void iFuseLibLogUnlock();
 
 #endif	/* IFUSE_LIB_UTIL_HPP */

--- a/include/iFuse.Lib.hpp
+++ b/include/iFuse.Lib.hpp
@@ -16,6 +16,7 @@ typedef struct IFuseExtendedOpt {
 typedef struct IFuseOpt {
     char *program;
     bool debug;
+    bool nonempty;
     bool foreground;
     bool bufferedFS;
     bool preload;

--- a/include/iFuse.Lib.hpp
+++ b/include/iFuse.Lib.hpp
@@ -15,6 +15,8 @@ typedef struct IFuseExtendedOpt {
 
 typedef struct IFuseOpt {
     char *program;
+    bool help;
+    bool version;
     bool debug;
     bool nonempty;
     bool foreground;
@@ -34,6 +36,8 @@ typedef struct IFuseOpt {
     iFuseExtendedOpt_t *extendedOpts;
 } iFuseOpt_t;
 
+typedef void (*iFuseLibTimerHandlerCB) ();
+
 rodsEnv *iFuseLibGetRodsEnv();
 void iFuseLibSetRodsEnv(rodsEnv *pEnv);
 iFuseOpt_t *iFuseLibGetOption();
@@ -42,5 +46,9 @@ void iFuseLibSetOption(iFuseOpt_t *pOpt);
 void iFuseLibInit();
 void iFuseLibDestroy();
 
+void iFuseLibInitTimerThread();
+void iFuseLibTerminateTimerThread();
+void iFuseLibSetTimerTickHandler(iFuseLibTimerHandlerCB callback);
+void iFuseLibUnsetTimerTickHandler(iFuseLibTimerHandlerCB callback);
 
 #endif	/* IFUSE_LIB_HPP */

--- a/include/iFuse.Lib.hpp
+++ b/include/iFuse.Lib.hpp
@@ -3,7 +3,7 @@
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_LIB_HPP
-#define	IFUSE_LIB_HPP
+#define IFUSE_LIB_HPP
 
 #include "rodsClient.h"
 
@@ -20,9 +20,16 @@ typedef struct IFuseOpt {
     bool foreground;
     bool bufferedFS;
     bool preload;
+    bool cacheMetadata;
     int maxConn;
+    int blocksize;
+    bool connReuse;
     int connTimeoutSec;
     int connKeepAliveSec;
+    int connCheckIntervalSec;
+    int rodsapiTimeoutSec;
+    int preloadNumBlocks;
+    int metadataCacheTimeoutSec;
     char *mountpoint;
     iFuseExtendedOpt_t *extendedOpts;
 } iFuseOpt_t;
@@ -37,4 +44,3 @@ void iFuseLibDestroy();
 
 
 #endif	/* IFUSE_LIB_HPP */
-

--- a/include/iFuse.Preload.hpp
+++ b/include/iFuse.Preload.hpp
@@ -3,7 +3,7 @@
 /*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSE_PRELOAD_HPP
-#define	IFUSE_PRELOAD_HPP
+#define IFUSE_PRELOAD_HPP
 
 #include <list>
 #include <pthread.h>
@@ -49,4 +49,3 @@ int iFusePreloadClose(iFuseFd_t *iFuseFd);
 int iFusePreloadRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size);
 
 #endif	/* IFUSE_PRELOAD_HPP */
-

--- a/include/iFuse.Preload.hpp
+++ b/include/iFuse.Preload.hpp
@@ -10,7 +10,8 @@
 #include "iFuse.BufferedFS.hpp"
 #include "iFuse.Lib.Fd.hpp"
 
-#define IFUSE_PRELOAD_PBLOCK_NUM         3
+#define IFUSE_PRELOAD_PBLOCK_NUM             3
+#define IFUSE_PRELOAD_MAX_PBLOCK_NUM         10
 
 #define IFUSE_PRELOAD_PBLOCK_STATUS_INIT                 0
 #define IFUSE_PRELOAD_PBLOCK_STATUS_RUNNING              1
@@ -24,16 +25,16 @@ typedef struct IFusePreloadPBlock {
     int status;
     bool threadJoined;
     pthread_t thread;
-    pthread_mutexattr_t lockAttr;
-    pthread_mutex_t lock;
+    pthread_rwlockattr_t lockAttr;
+    pthread_rwlock_t lock;
 } iFusePreloadPBlock_t;
 
 typedef struct IFusePreload {
     unsigned long fdId;
     char *iRodsPath;
     std::list<iFusePreloadPBlock_t*> *pblocks;
-    pthread_mutexattr_t lockAttr;
-    pthread_mutex_t lock;
+    pthread_rwlockattr_t lockAttr;
+    pthread_rwlock_t lock;
 } iFusePreload_t;
 
 typedef struct IFusePreloadThreadParam {

--- a/include/iFuseCmdLineOpt.hpp
+++ b/include/iFuseCmdLineOpt.hpp
@@ -3,7 +3,7 @@
 /*** This code is written by Illyoung Choi (iychoi@email.arizona.edu)      ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #ifndef IFUSECMDLINEOPT_HPP
-#define	IFUSECMDLINEOPT_HPP
+#define IFUSECMDLINEOPT_HPP
 
 #include "iFuse.Lib.hpp"
 
@@ -16,4 +16,3 @@ void iFuseGenCmdLineForFuse(int *fuse_argc, char ***fuse_argv);
 void iFuseReleaseCmdLineForFuse(int fuse_argc, char **fuse_argv);
 
 #endif	/* IFUSECMDLINEOPT_HPP */
-

--- a/include/iFuseOper.hpp
+++ b/include/iFuseOper.hpp
@@ -39,6 +39,7 @@ extern "C" {
     int iFuseChmod(const char *path, mode_t mode);
     int iFuseChown(const char *path, uid_t uid, gid_t gid);
     int iFuseUtimens(const char *path, const struct timespec ts[]);
+    int iFuseIoctl(const char *path, int cmd, void *arg, struct fuse_file_info *fi, unsigned int flags, void *data);
 #ifdef  __cplusplus
 }
 #endif

--- a/src/iFuse.BufferedFS.cpp
+++ b/src/iFuse.BufferedFS.cpp
@@ -25,7 +25,7 @@ static pthread_mutex_t g_BufferCacheLock;
 static std::map<std::string, iFuseBufferCache_t*> g_DeltaMap;
 static std::map<unsigned long, iFuseBufferCache_t*> g_CacheMap;
 
-static int g_blocksize = IFUSE_BUFFER_CACHE_BLOCK_SIZE;
+static int g_Blocksize = IFUSE_BUFFER_CACHE_BLOCK_SIZE;
 
 static int _newBufferCache(iFuseBufferCache_t **iFuseBufferCache) {
     iFuseBufferCache_t *tmpIFuseBufferCache = NULL;
@@ -65,19 +65,19 @@ static int _freeBufferCache(iFuseBufferCache_t *iFuseBufferCache) {
 }
 
 size_t getBufferCacheBlockSize() {
-    return g_blocksize;
+    return g_Blocksize;
 }
 
 unsigned int getBlockID(off_t off) {
     assert(off >= 0);
 
-    return off / g_blocksize;
+    return off / g_Blocksize;
 }
 
 off_t getBlockStartOffset(unsigned int blockID) {
     off_t blockStartOffset = 0;
 
-    blockStartOffset = (off_t)blockID * g_blocksize;
+    blockStartOffset = (off_t)blockID * g_Blocksize;
 
     assert(blockStartOffset >= 0);
 
@@ -225,13 +225,13 @@ static int _readBlock(iFuseFd_t *iFuseFd, char *buf, unsigned int blockID) {
         assert(iFuseBufferCache != NULL);
 
         // read from server
-        blockBuffer = (char*)calloc(1, g_blocksize);
+        blockBuffer = (char*)calloc(1, g_Blocksize);
         if(blockBuffer == NULL) {
             _freeBufferCache(iFuseBufferCache);
             return SYS_MALLOC_ERR;
         }
 
-        status = iFuseFsRead(iFuseFd, blockBuffer, blockStartOffset, g_blocksize);
+        status = iFuseFsRead(iFuseFd, blockBuffer, blockStartOffset, g_Blocksize);
         if (status < 0) {
             iFuseRodsClientLogError(LOG_ERROR, status, "_readBlock: iFuseFsRead of %s error, status = %d",
                     iFuseFd->iRodsPath, status);
@@ -436,7 +436,7 @@ static int _releaseAllCache() {
 void iFuseBufferedFSInit() {
    
     if(iFuseLibGetOption()->blocksize > 0) {
-        g_blocksize = iFuseLibGetOption()->blocksize;
+        g_Blocksize = iFuseLibGetOption()->blocksize;
     }
    
     pthread_mutexattr_init(&g_BufferCacheLockAttr);
@@ -615,7 +615,7 @@ int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size) {
     size_t readSize = 0;
     size_t remain = 0;
     off_t curOffset = 0;
-    char *blockBuffer = (char*)calloc(1, g_blocksize);
+    char *blockBuffer = (char*)calloc(1, g_Blocksize);
     if(blockBuffer == NULL) {
         return SYS_MALLOC_ERR;
     }
@@ -630,7 +630,7 @@ int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size) {
     curOffset = off;
     while(remain > 0) {
         off_t inBlockOffset = getInBlockOffset(curOffset);
-        size_t inBlockAvail = g_blocksize - inBlockOffset;
+        size_t inBlockAvail = g_Blocksize - inBlockOffset;
         size_t curSize = inBlockAvail > remain ? remain : inBlockAvail;
         size_t blockSize = 0;
 
@@ -666,7 +666,7 @@ int iFuseBufferedFsRead(iFuseFd_t *iFuseFd, char *buf, off_t off, size_t size) {
         remain -= curSize;
         curOffset += curSize;
 
-        if(blockSize < (size_t)g_blocksize) {
+        if(blockSize < (size_t)g_Blocksize) {
             // eof
             break;
         }
@@ -696,7 +696,7 @@ int iFuseBufferedFsWrite(iFuseFd_t *iFuseFd, const char *buf, off_t off, size_t 
     curOffset = off;
     while(remain > 0) {
         off_t inBlockOffset = getInBlockOffset(curOffset);
-        size_t inBlockAvail = g_blocksize - inBlockOffset;
+        size_t inBlockAvail = g_Blocksize - inBlockOffset;
         size_t curSize = inBlockAvail > remain ? remain : inBlockAvail;
 
         assert(curSize > 0);

--- a/src/iFuse.FS.cpp
+++ b/src/iFuse.FS.cpp
@@ -18,8 +18,8 @@
 #include "iFuse.Lib.Util.hpp"
 #include "sockComm.h"
 
-static bool g_connReuse = false;
-static bool g_cacheMetadata = true;
+static bool g_ConnReuse = false;
+static bool g_CacheMetadata = true;
 
 static int _safeAtoi(char *str) {
     if(str == NULL) {
@@ -69,8 +69,8 @@ static int _fillDirStat(struct stat *stbuf, uint ino, uint ctime, uint mtime, ui
  * Initialize filesystem
  */
 void iFuseFsInit() {
-    g_connReuse = iFuseLibGetOption()->connReuse;
-    g_cacheMetadata = iFuseLibGetOption()->cacheMetadata;
+    g_ConnReuse = iFuseLibGetOption()->connReuse;
+    g_CacheMetadata = iFuseLibGetOption()->cacheMetadata;
 }
 
 /*
@@ -91,7 +91,7 @@ int iFuseFsGetAttr(const char *iRodsPath, struct stat *stbuf) {
     iFuseRodsClientLog(LOG_DEBUG, "iFuseFsGetAttr: %s", iRodsPath);
 
     // check stat cache if available
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheClearExpiredStat(false);
       
         status = iFuseMetadataCacheGetStat(iRodsPath, stbuf);
@@ -104,7 +104,7 @@ int iFuseFsGetAttr(const char *iRodsPath, struct stat *stbuf) {
 
     // temporarily obtain a connection
     // must be marked unused and release lock after use
-    if(g_connReuse) {
+    if(g_ConnReuse) {
         status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_SHORTOP);
     } else {
         status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_ONETIMEUSE);
@@ -172,7 +172,7 @@ int iFuseFsGetAttr(const char *iRodsPath, struct stat *stbuf) {
                      _safeAtoi(rodsObjStatOut->modifyTime),
                      _safeAtoi(rodsObjStatOut->modifyTime));
                      
-        if(g_cacheMetadata) {
+        if(g_CacheMetadata) {
             iFuseMetadataCachePutStat(iRodsPath, stbuf);
         }
         
@@ -188,7 +188,7 @@ int iFuseFsGetAttr(const char *iRodsPath, struct stat *stbuf) {
                       _safeAtoi(rodsObjStatOut->modifyTime),
                       _safeAtoi(rodsObjStatOut->modifyTime));
                       
-        if(g_cacheMetadata) {
+        if(g_CacheMetadata) {
             iFuseMetadataCachePutStat(iRodsPath, stbuf);
         }
         
@@ -214,7 +214,7 @@ int iFuseFsOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag) {
     // obtain a connection for a file
     // must be released lock after use
     // while the file is opened, connection is in-use status.
-    if(g_connReuse) {
+    if(g_ConnReuse) {
         status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_FILE_IO);
     } else {
         status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_ONETIMEUSE);
@@ -234,7 +234,7 @@ int iFuseFsOpen(const char *iRodsPath, iFuseFd_t **iFuseFd, int openFlag) {
     }
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         if((openFlag & O_ACCMODE) != O_RDONLY) {
             iFuseMetadataCacheRemoveStat(iRodsPath);
         }
@@ -270,7 +270,7 @@ int iFuseFsClose(iFuseFd_t *iFuseFd) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         if((iFuseFd->openFlag & O_ACCMODE) != O_RDONLY) {
             iFuseMetadataCacheRemoveStat(iFuseFd->iRodsPath);
         }
@@ -605,7 +605,7 @@ int iFuseFsFlush(iFuseFd_t *iFuseFd) {
     }
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iFuseFd->iRodsPath);
     }
 
@@ -719,7 +719,7 @@ int iFuseFsCreate(const char *iRodsPath, mode_t mode) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
         
         // Add an entry to parent dir
@@ -794,7 +794,7 @@ int iFuseFsUnlink(const char *iRodsPath) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
         
         // remove file from parent dir
@@ -817,7 +817,7 @@ int iFuseFsOpenDir(const char *iRodsPath, iFuseDir_t **iFuseDir) {
     iFuseRodsClientLog(LOG_DEBUG, "iFuseFsOpenDir: %s", iRodsPath);
 
     // check dir entry cache if available
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheClearExpiredDir(false);
         
         status = iFuseMetadataCacheGetDirEntry(iRodsPath, &entries, &entrybufferLen);
@@ -849,7 +849,7 @@ int iFuseFsOpenDir(const char *iRodsPath, iFuseDir_t **iFuseDir) {
         // obtain a connection for a file
         // must be released lock after use
         // while the file is opened, connection is in-use status.
-        if(g_connReuse) {
+        if(g_ConnReuse) {
             status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_FILE_IO);
         } else {
             status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_ONETIMEUSE);
@@ -919,7 +919,7 @@ int iFuseFsReadDir(iFuseDir_t *iFuseDir, iFuseDirFiller filler, void *buf, off_t
     iFuseRodsClientLog(LOG_DEBUG, "iFuseFsReadDir: %s", iFuseDir->iRodsPath);
 
     // check dir entry cache if available
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         if(iFuseDir->cachedEntries != NULL) {
             // has dir entry cache
             iFuseRodsClientLog(LOG_DEBUG, "iFuseFsReadDir: use cached dir entries of %s", iFuseDir->iRodsPath);
@@ -948,7 +948,7 @@ int iFuseFsReadDir(iFuseDir_t *iFuseDir, iFuseDirFiller filler, void *buf, off_t
     
     while ((status = iFuseRodsClientReadCollection(iFuseConn->conn, iFuseDir->handle, &collEnt)) >= 0) {
         if (collEnt.objType == DATA_OBJ_T) {
-            if(g_cacheMetadata) {
+            if(g_CacheMetadata) {
                 bzero(&stbuf, sizeof ( struct stat));
                 _fillFileStat(&stbuf,
                               _safeAtoi(collEnt.dataId),
@@ -968,7 +968,7 @@ int iFuseFsReadDir(iFuseDir_t *iFuseDir, iFuseDirFiller filler, void *buf, off_t
 
             status2 = iFuseLibGetFilename(collEnt.collName, filename, MAX_NAME_LEN);
             if (status2 == 0) {
-                if(g_cacheMetadata) {
+                if(g_CacheMetadata) {
                     bzero(&stbuf, sizeof ( struct stat));
                     _fillDirStat(&stbuf,
                                  _safeAtoi(collEnt.dataId),
@@ -1045,7 +1045,7 @@ int iFuseFsMakeDir(const char *iRodsPath, mode_t mode) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
         
         // add dir
@@ -1137,7 +1137,7 @@ int iFuseFsRemoveDir(const char *iRodsPath) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
         
         // remove dir
@@ -1216,7 +1216,7 @@ int iFuseFsRename(const char *iRodsFromPath, const char *iRodsToPath) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsFromPath);
         iFuseMetadataCacheRemoveStat(iRodsToPath);
         
@@ -1289,7 +1289,7 @@ int iFuseFsTruncate(const char *iRodsPath, off_t size) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
     }
     
@@ -1371,9 +1371,37 @@ int iFuseFsChmod(const char *iRodsPath, mode_t mode) {
     iFuseConnUnuse(iFuseConn);
     
     // clear stat cache
-    if(g_cacheMetadata) {
+    if(g_CacheMetadata) {
         iFuseMetadataCacheRemoveStat(iRodsPath);
     }
     
+    return 0;
+}
+
+int iFuseFsIoctl(const char *iRodsPath, int cmd, void *arg, struct fuse_file_info *fi, unsigned int flags, void *data) {
+    assert(iRodsPath != NULL);
+
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseFsIoctl: %s", iRodsPath);
+    
+    UNUSED(arg);
+    UNUSED(fi);
+    UNUSED(flags);
+    UNUSED(data);
+    
+    switch (cmd) {
+    	case IFUSEIOC_RESET_METADATA_CACHE:
+            {
+                // clear cache
+                if(g_CacheMetadata) {
+                    iFuseRodsClientLog(LOG_DEBUG, "iFuseFsIoctl: clearing all cache");
+                    iFuseMetadataCacheClear();
+                }
+            }
+        	return 0;
+
+    	default:
+    		return 0;
+	}
+
     return 0;
 }

--- a/src/iFuse.Lib.Conn.cpp
+++ b/src/iFuse.Lib.Conn.cpp
@@ -30,6 +30,7 @@ static unsigned long g_connIDGen;
 static int g_maxConnNum = IFUSE_MAX_NUM_CONN;
 static int g_connTimeoutSec = IFUSE_FREE_CONN_TIMEOUT_SEC;
 static int g_connKeepAliveSec = IFUSE_FREE_CONN_KEEPALIVE_SEC;
+static int g_connCheckIntervalSec = IFUSE_FREE_CONN_CHECK_INTERVAL_SEC;
 
 /*
  * Lock order :
@@ -244,7 +245,7 @@ static void* _connChecker(void* param) {
 
         for(i=0;i<g_maxConnNum;i++) {
             if(g_InUseConn[i] != NULL) {
-                if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseConn[i]->lastKeepAliveTime) >= g_connKeepAliveSec) {
+                if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseConn[i]->lastKeepAliveTime) >= g_connKeepAliveSec) {
                     _keepAlive(g_InUseConn[i]);
                     g_InUseConn[i]->lastKeepAliveTime = iFuseLibGetCurrentTime();
                 }
@@ -252,7 +253,7 @@ static void* _connChecker(void* param) {
         }
 
         if(g_InUseShortopConn != NULL) {
-            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseShortopConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseShortopConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
                 _keepAlive(g_InUseShortopConn);
                 g_InUseShortopConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
             }
@@ -261,7 +262,7 @@ static void* _connChecker(void* param) {
         for(it_connmap=g_InUseOnetimeuseConn.begin();it_connmap!=g_InUseOnetimeuseConn.end();it_connmap++) {
             iFuseConn = it_connmap->second;
 
-            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->lastKeepAliveTime) >= g_connKeepAliveSec) {
                 _keepAlive(iFuseConn);
                 iFuseConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
             }
@@ -273,7 +274,7 @@ static void* _connChecker(void* param) {
         for(it_conn=g_FreeConn.begin();it_conn!=g_FreeConn.end();it_conn++) {
             iFuseConn = *it_conn;
 
-            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->actTime) >= g_connTimeoutSec) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->actTime) >= g_connTimeoutSec) {
                 removeList.push_back(iFuseConn);
             }
         }
@@ -287,7 +288,7 @@ static void* _connChecker(void* param) {
         }
 
         if(g_FreeShortopConn != NULL) {
-            if(IFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_FreeShortopConn->actTime) >= g_connTimeoutSec) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_FreeShortopConn->actTime) >= g_connTimeoutSec) {
                 _freeConn(g_FreeShortopConn);
                 g_FreeShortopConn = NULL;
             }
@@ -295,7 +296,7 @@ static void* _connChecker(void* param) {
 
         pthread_mutex_unlock(&g_ConnectedConnLock);
 
-        sleep(IFUSE_FREE_CONN_CHECK_PERIOD);
+        sleep(g_connCheckIntervalSec);
     }
 
     return NULL;
@@ -338,14 +339,14 @@ int iFuseConnTest() {
         return -1;
     }
     
-    iFuseRodsClientLog(LOG_DEBUG, "checkICatHost: make a test connection to iRODS host - %s:%d", myRodsEnv->rodsHost, myRodsEnv->rodsPort);
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseConnTest: make a test connection to iRODS host - %s:%d", myRodsEnv->rodsHost, myRodsEnv->rodsPort);
     
     conn = iFuseRodsClientConnect(myRodsEnv->rodsHost, myRodsEnv->rodsPort,
                 myRodsEnv->rodsUserName, myRodsEnv->rodsZone, NO_RECONN, &errMsg);
     if (conn == NULL) {
         // failed
         iFuseRodsClientLogError(LOG_ERROR, errMsg.status,
-                "checkICatHost: iFuseRodsClientConnect failure %s", errMsg.msg);
+                "iFuseConnTest: iFuseRodsClientConnect failure %s", errMsg.msg);
         fprintf(stderr, "Cannot connect to iRODS Host - %s:%d error - %s\n", myRodsEnv->rodsHost, myRodsEnv->rodsPort, errMsg.msg);
         if (errMsg.status < 0) {
             return errMsg.status;
@@ -354,7 +355,7 @@ int iFuseConnTest() {
         }
     }
     
-    iFuseRodsClientLog(LOG_DEBUG, "checkICatHost: logging in to iRODS - account %s", myRodsEnv->rodsUserName);
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseConnTest: logging in to iRODS - account %s", myRodsEnv->rodsUserName);
 
     status = iFuseRodsClientLogin(conn);
     if (status != 0) {
@@ -389,6 +390,10 @@ void iFuseConnInit() {
     if(iFuseLibGetOption()->connKeepAliveSec > 0) {
         g_connKeepAliveSec = iFuseLibGetOption()->connKeepAliveSec;
     }
+    
+    if(iFuseLibGetOption()->connCheckIntervalSec > 0) {
+        g_connCheckIntervalSec = iFuseLibGetOption()->connCheckIntervalSec;
+   }
 
     pthread_mutexattr_init(&g_ConnectedConnLockAttr);
     pthread_mutexattr_settype(&g_ConnectedConnLockAttr, PTHREAD_MUTEX_RECURSIVE);

--- a/src/iFuse.Lib.Conn.cpp
+++ b/src/iFuse.Lib.Conn.cpp
@@ -15,22 +15,26 @@
 #include "iFuse.Lib.Conn.hpp"
 #include "iFuse.Lib.Util.hpp"
 
-static pthread_mutex_t g_ConnectedConnLock;
-static pthread_mutexattr_t g_ConnectedConnLockAttr;
+static pthread_rwlock_t g_ConnectedConnLock;
+static pthread_rwlockattr_t g_ConnectedConnLockAttr;
+
 static iFuseConn_t* g_InUseShortopConn;
 static iFuseConn_t** g_InUseConn;
 static std::map<unsigned long, iFuseConn_t*> g_InUseOnetimeuseConn;
 static iFuseConn_t* g_FreeShortopConn;
 static std::list<iFuseConn_t*> g_FreeConn;
 
-static pthread_t g_FreeConnCollector;
-static bool g_FreeConnCollectorRunning;
+static pthread_rwlockattr_t g_IDGenLockAttr;
+static pthread_rwlock_t g_IDGenLock;
+
 static unsigned long g_ConnIDGen;
 
 static int g_MaxConnNum = IFUSE_MAX_NUM_CONN;
 static int g_ConnTimeoutSec = IFUSE_FREE_CONN_TIMEOUT_SEC;
 static int g_ConnKeepAliveSec = IFUSE_FREE_CONN_KEEPALIVE_SEC;
 static int g_ConnCheckIntervalSec = IFUSE_FREE_CONN_CHECK_INTERVAL_SEC;
+
+static time_t g_LastConnCheck = 0;
 
 /*
  * Lock order :
@@ -39,7 +43,15 @@ static int g_ConnCheckIntervalSec = IFUSE_FREE_CONN_CHECK_INTERVAL_SEC;
  */
 
 static unsigned long _genNextConnID() {
-    return g_ConnIDGen++;
+    unsigned long newId;
+    
+    pthread_rwlock_wrlock(&g_IDGenLock);
+    
+    newId = g_ConnIDGen++;
+    
+    pthread_rwlock_unlock(&g_IDGenLock);
+    
+    return newId;
 }
 
 static int _connect(iFuseConn_t *iFuseConn) {
@@ -49,8 +61,6 @@ static int _connect(iFuseConn_t *iFuseConn) {
 
     assert(myRodsEnv != NULL);
     assert(iFuseConn != NULL);
-
-    pthread_mutex_lock(&iFuseConn->lock);
 
     if (iFuseConn->conn == NULL) {
         rErrMsg_t errMsg;
@@ -62,10 +72,9 @@ static int _connect(iFuseConn_t *iFuseConn) {
                     myRodsEnv->rodsUserName, myRodsEnv->rodsZone, reconnFlag, &errMsg);
             if (iFuseConn->conn == NULL) {
                 // failed
-                iFuseRodsClientLogError(LOG_ERROR, errMsg.status,
+                iFuseLibLogError(LOG_ERROR, errMsg.status,
                         "_connect: iFuseRodsClientConnect failure %s", errMsg.msg);
-                iFuseRodsClientLog(LOG_ERROR, "Cannot connect to iRODS Host - %s:%d error - %s", myRodsEnv->rodsHost, myRodsEnv->rodsPort, errMsg.msg);
-                pthread_mutex_unlock(&iFuseConn->lock);
+                iFuseLibLog(LOG_ERROR, "Cannot connect to iRODS Host - %s:%d error - %s", myRodsEnv->rodsHost, myRodsEnv->rodsPort, errMsg.msg);
                 if (errMsg.status < 0) {
                     return errMsg.status;
                 } else {
@@ -82,26 +91,21 @@ static int _connect(iFuseConn_t *iFuseConn) {
             iFuseConn->conn = NULL;
 
             // failed
-            iFuseRodsClientLog(LOG_ERROR, "iFuseRodsClientLogin failure, status = %d", status);
-            iFuseRodsClientLog(LOG_ERROR, "Cannot log in to iRODS - account %s", myRodsEnv->rodsUserName);
+            iFuseLibLog(LOG_ERROR, "iFuseRodsClientLogin failure, status = %d", status);
+            iFuseLibLog(LOG_ERROR, "Cannot log in to iRODS - account %s", myRodsEnv->rodsUserName);
         }
     }
 
-    pthread_mutex_unlock(&iFuseConn->lock);
     return status;
 }
 
 static void _disconnect(iFuseConn_t *iFuseConn) {
     assert(iFuseConn != NULL);
 
-    pthread_mutex_lock(&iFuseConn->lock);
-
     if (iFuseConn->conn != NULL) {
         iFuseRodsClientDisconnect(iFuseConn->conn);
         iFuseConn->conn = NULL;
     }
-
-    pthread_mutex_unlock(&iFuseConn->lock);
 }
 
 static int _newConn(iFuseConn_t **iFuseConn) {
@@ -118,14 +122,14 @@ static int _newConn(iFuseConn_t **iFuseConn) {
 
     tmpIFuseConn->connId = _genNextConnID();
 
-    iFuseRodsClientLog(LOG_DEBUG, "_newConn: creating a new connection - %lu", tmpIFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "_newConn: creating a new connection - %lu", tmpIFuseConn->connId);
 
-    pthread_mutexattr_init(&tmpIFuseConn->lockAttr);
-    pthread_mutexattr_settype(&tmpIFuseConn->lockAttr, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(&tmpIFuseConn->lock, &tmpIFuseConn->lockAttr);
-
+    pthread_rwlockattr_init(&tmpIFuseConn->lockAttr);
+    pthread_rwlock_init(&tmpIFuseConn->lock, &tmpIFuseConn->lockAttr);
+    
     // connect
     status = _connect(tmpIFuseConn);
+    tmpIFuseConn->lastActTime = iFuseLibGetCurrentTime();
     *iFuseConn = tmpIFuseConn;
     return status;
 }
@@ -133,13 +137,13 @@ static int _newConn(iFuseConn_t **iFuseConn) {
 static int _freeConn(iFuseConn_t *iFuseConn) {
     assert(iFuseConn != NULL);
 
-    iFuseRodsClientLog(LOG_DEBUG, "_freeConn: disconnecting - %lu", iFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "_freeConn: disconnecting - %lu", iFuseConn->connId);
 
     // disconnect first
     _disconnect(iFuseConn);
 
-    pthread_mutex_destroy(&iFuseConn->lock);
-    pthread_mutexattr_destroy(&iFuseConn->lockAttr);
+    pthread_rwlock_destroy(&iFuseConn->lock);
+    pthread_rwlockattr_destroy(&iFuseConn->lockAttr);
 
     free(iFuseConn);
     return 0;
@@ -150,7 +154,7 @@ static int _freeAllConn() {
     std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
     int i;
 
-    pthread_mutex_lock(&g_ConnectedConnLock);
+    pthread_rwlock_wrlock(&g_ConnectedConnLock);
 
     // disconnect all free connections
     while(!g_FreeConn.empty()) {
@@ -189,7 +193,7 @@ static int _freeAllConn() {
         }
     }
     
-    pthread_mutex_unlock(&g_ConnectedConnLock);
+    pthread_rwlock_unlock(&g_ConnectedConnLock);
 
     return 0;
 }
@@ -203,23 +207,23 @@ static void _keepAlive(iFuseConn_t *iFuseConn) {
     bzero(iRodsPath, MAX_NAME_LEN);
     status = iFuseRodsClientMakeRodsPath("/", iRodsPath);
     if (status < 0) {
-        iFuseRodsClientLogError(LOG_ERROR, status,
+        iFuseLibLogError(LOG_ERROR, status,
                 "_keepAlive: iFuseRodsClientMakeRodsPath of %s error", iRodsPath);
         return;
     }
 
-    iFuseRodsClientLog(LOG_DEBUG, "_keepAlive: %s", iRodsPath);
+    iFuseLibLog(LOG_DEBUG, "_keepAlive: connection %lu", iFuseConn->connId);
 
     bzero(&dataObjInp, sizeof ( dataObjInp_t));
     rstrcpy(dataObjInp.objPath, iRodsPath, MAX_NAME_LEN);
 
-    iFuseConnLock(iFuseConn);
+    pthread_rwlock_wrlock(&iFuseConn->lock);
 
     status = iFuseRodsClientObjStat(iFuseConn->conn, &dataObjInp, &rodsObjStatOut);
     if (status < 0) {
-        iFuseRodsClientLogError(LOG_ERROR, status, "_keepAlive: iFuseRodsClientObjStat of %s error, status = %d",
+        iFuseLibLogError(LOG_ERROR, status, "_keepAlive: iFuseRodsClientObjStat of %s error, status = %d",
             iRodsPath, status);
-        iFuseConnUnlock(iFuseConn);
+        pthread_rwlock_unlock(&iFuseConn->lock);
         return;
     }
 
@@ -227,55 +231,73 @@ static void _keepAlive(iFuseConn_t *iFuseConn) {
         freeRodsObjStat(rodsObjStatOut);
     }
 
-    iFuseConnUnlock(iFuseConn);
+    // update last act time
+    iFuseConn->lastActTime = iFuseLibGetCurrentTime();
+
+    pthread_rwlock_unlock(&iFuseConn->lock);
 }
 
-static void* _connChecker(void* param) {
+static void _connChecker() {
     std::list<iFuseConn_t*> removeList;
     std::list<iFuseConn_t*>::iterator it_conn;
     std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
     iFuseConn_t *iFuseConn;
+    time_t current;
     int i;
+    
+    //iFuseLibLog(LOG_DEBUG, "_connChecker is called");
+    
+    current = iFuseLibGetCurrentTime();
 
-    UNUSED(param);
-
-    iFuseRodsClientLog(LOG_DEBUG, "_connChecker: collector is running");
-
-    while(g_FreeConnCollectorRunning) {
-        pthread_mutex_lock(&g_ConnectedConnLock);
+    if(iFuseLibDiffTimeSec(current, g_LastConnCheck) > g_ConnCheckIntervalSec) {
+        //iFuseLibLog(LOG_DEBUG, "_connChecker: sending keep-alive requests");
+        pthread_rwlock_rdlock(&g_ConnectedConnLock);
 
         for(i=0;i<g_MaxConnNum;i++) {
             if(g_InUseConn[i] != NULL) {
-                if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseConn[i]->lastKeepAliveTime) >= g_ConnKeepAliveSec) {
+                if(iFuseLibDiffTimeSec(current, g_InUseConn[i]->lastActTime) >= g_ConnKeepAliveSec) {
                     _keepAlive(g_InUseConn[i]);
-                    g_InUseConn[i]->lastKeepAliveTime = iFuseLibGetCurrentTime();
                 }
             }
         }
 
         if(g_InUseShortopConn != NULL) {
-            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_InUseShortopConn->lastKeepAliveTime) >= g_ConnKeepAliveSec) {
+            if(iFuseLibDiffTimeSec(current, g_InUseShortopConn->lastActTime) >= g_ConnKeepAliveSec) {
                 _keepAlive(g_InUseShortopConn);
-                g_InUseShortopConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
             }
         }
 
         for(it_connmap=g_InUseOnetimeuseConn.begin();it_connmap!=g_InUseOnetimeuseConn.end();it_connmap++) {
             iFuseConn = it_connmap->second;
 
-            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->lastKeepAliveTime) >= g_ConnKeepAliveSec) {
+            if(iFuseLibDiffTimeSec(current, iFuseConn->lastActTime) >= g_ConnKeepAliveSec) {
                 _keepAlive(iFuseConn);
-                iFuseConn->lastKeepAliveTime = iFuseLibGetCurrentTime();
             }
         }
+        
+        for(it_conn=g_FreeConn.begin();it_conn!=g_FreeConn.end();it_conn++) {
+            iFuseConn = *it_conn;
 
-        //iFuseRodsClientLog(LOG_DEBUG, "_freeConnCollector: checking idle connections");
+            if(iFuseLibDiffTimeSec(current, iFuseConn->lastActTime) >= g_ConnKeepAliveSec) {
+                _keepAlive(iFuseConn);
+            }
+        }
+        
+        if(g_FreeShortopConn != NULL) {
+            if(iFuseLibDiffTimeSec(current, g_FreeShortopConn->lastActTime) >= g_ConnKeepAliveSec) {
+                _keepAlive(g_FreeShortopConn);
+            }
+        }
+        
+        pthread_rwlock_unlock(&g_ConnectedConnLock);
 
+        pthread_rwlock_wrlock(&g_ConnectedConnLock);
         // iterate free conn list to check timedout connections
         for(it_conn=g_FreeConn.begin();it_conn!=g_FreeConn.end();it_conn++) {
             iFuseConn = *it_conn;
 
-            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseConn->actTime) >= g_ConnTimeoutSec) {
+            if(iFuseLibDiffTimeSec(current, iFuseConn->lastUseTime) >= g_ConnTimeoutSec) {
+                iFuseLibLog(LOG_DEBUG, "_connChecker: release idle connection %lu", iFuseConn->connId);
                 removeList.push_back(iFuseConn);
             }
         }
@@ -289,18 +311,16 @@ static void* _connChecker(void* param) {
         }
 
         if(g_FreeShortopConn != NULL) {
-            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_FreeShortopConn->actTime) >= g_ConnTimeoutSec) {
+            if(iFuseLibDiffTimeSec(current, g_FreeShortopConn->lastUseTime) >= g_ConnTimeoutSec) {
                 _freeConn(g_FreeShortopConn);
                 g_FreeShortopConn = NULL;
             }
         }
 
-        pthread_mutex_unlock(&g_ConnectedConnLock);
-
-        sleep(g_ConnCheckIntervalSec);
+        pthread_rwlock_unlock(&g_ConnectedConnLock);
+        
+        g_LastConnCheck = iFuseLibGetCurrentTime();
     }
-
-    return NULL;
 }
 
 int iFuseConnTest() {
@@ -310,40 +330,40 @@ int iFuseConnTest() {
     
     //check host
     if(myRodsEnv == NULL) {
-        iFuseRodsClientLog(LOG_ERROR, "Cannot read rods environment");
+        iFuseLibLog(LOG_ERROR, "Cannot read rods environment");
         fprintf(stderr, "Cannot read rods environment\n");
         return -1;
     }
     
-    if(myRodsEnv->rodsHost == NULL || strlen(myRodsEnv->rodsHost) == 0) {
-        iFuseRodsClientLog(LOG_ERROR, "iRODS Host is not configured in rods environment");
+    if(strlen(myRodsEnv->rodsHost) == 0) {
+        iFuseLibLog(LOG_ERROR, "iRODS Host is not configured in rods environment");
         fprintf(stderr, "iRODS Host is not configured in rods environment\n");
         return -1;
     }
     
     if(myRodsEnv->rodsPort <= 0) {
-        iFuseRodsClientLog(LOG_ERROR, "iRODS Port is not configured in rods environment");
+        iFuseLibLog(LOG_ERROR, "iRODS Port is not configured in rods environment");
         fprintf(stderr, "iRODS Port is not configured in rods environment\n");
         return -1;
     }
     
-    if(myRodsEnv->rodsUserName == NULL || strlen(myRodsEnv->rodsUserName) == 0) {
-        iFuseRodsClientLog(LOG_ERROR, "iRODS User Account is not configured in rods environment");
+    if(strlen(myRodsEnv->rodsUserName) == 0) {
+        iFuseLibLog(LOG_ERROR, "iRODS User Account is not configured in rods environment");
         fprintf(stderr, "iRODS User Account is not configured in rods environment\n");
         return -1;
     }
     
-    if(myRodsEnv->rodsZone == NULL || strlen(myRodsEnv->rodsZone) == 0) {
-        iFuseRodsClientLog(LOG_ERROR, "iRODS Zone is not configured in rods environment");
+    if(strlen(myRodsEnv->rodsZone) == 0) {
+        iFuseLibLog(LOG_ERROR, "iRODS Zone is not configured in rods environment");
         fprintf(stderr, "iRODS Zone is not configured in rods environment\n");
         return -1;
     }
     
-    iFuseRodsClientLog(LOG_DEBUG, "iFuseConnTest: make a test connection to iRODS host - %s:%d", myRodsEnv->rodsHost, myRodsEnv->rodsPort);
+    iFuseLibLog(LOG_DEBUG, "iFuseConnTest: make a test connection to iRODS host - %s:%d", myRodsEnv->rodsHost, myRodsEnv->rodsPort);
     
     status = iFuseConnGetAndUse(&iFuseConn, IFUSE_CONN_TYPE_FOR_SHORTOP);
     if (status < 0) {
-        iFuseRodsClientLogError(LOG_ERROR, status, "iFuseConnTest: iFuseConnGetAndUse error");
+        iFuseLibLogError(LOG_ERROR, status, "iFuseConnTest: iFuseConnGetAndUse error");
         fprintf(stderr, "Cannot establish a connection");
         return status;
     }
@@ -374,9 +394,8 @@ void iFuseConnInit() {
         g_ConnCheckIntervalSec = iFuseLibGetOption()->connCheckIntervalSec;
    }
 
-    pthread_mutexattr_init(&g_ConnectedConnLockAttr);
-    pthread_mutexattr_settype(&g_ConnectedConnLockAttr, PTHREAD_MUTEX_RECURSIVE);
-    pthread_mutex_init(&g_ConnectedConnLock, &g_ConnectedConnLockAttr);
+    pthread_rwlockattr_init(&g_ConnectedConnLockAttr);
+    pthread_rwlock_init(&g_ConnectedConnLock, &g_ConnectedConnLockAttr);
 
     g_InUseConn = (iFuseConn_t**)calloc(g_MaxConnNum, sizeof(iFuseConn_t*));
 
@@ -385,28 +404,83 @@ void iFuseConnInit() {
     }
 
     g_ConnIDGen = 0;
+    
+    pthread_rwlockattr_init(&g_IDGenLockAttr);
+    pthread_rwlock_init(&g_IDGenLock, &g_IDGenLockAttr);
 
-    g_FreeConnCollectorRunning = true;
-
-    pthread_create(&g_FreeConnCollector, NULL, _connChecker, NULL);
+    iFuseLibSetTimerTickHandler(_connChecker);
 }
 
 /*
  * Destroy Conn Manager
  */
 void iFuseConnDestroy() {
+    iFuseLibUnsetTimerTickHandler(_connChecker);
+    
     g_ConnIDGen = 0;
-
-    g_FreeConnCollectorRunning = false;
 
     _freeAllConn();
 
-    pthread_join(g_FreeConnCollector, NULL);
-
-    pthread_mutex_destroy(&g_ConnectedConnLock);
-    pthread_mutexattr_destroy(&g_ConnectedConnLockAttr);
+    pthread_rwlock_destroy(&g_ConnectedConnLock);
+    pthread_rwlockattr_destroy(&g_ConnectedConnLockAttr);
 
     free(g_InUseConn);
+    
+    pthread_rwlock_destroy(&g_IDGenLock);
+    pthread_rwlockattr_destroy(&g_IDGenLockAttr);
+}
+
+/*
+ * Report status of connections
+ */
+void iFuseConnReport(iFuseFsConnReport_t *report) {
+    std::list<iFuseConn_t*>::iterator it_conn;
+    std::map<unsigned long, iFuseConn_t*>::iterator it_connmap;
+    iFuseConn_t *iFuseConn;
+    int i;
+    time_t current;
+    
+    assert(report != NULL);
+    
+    bzero(report, sizeof(iFuseFsConnReport_t));
+
+    pthread_rwlock_rdlock(&g_ConnectedConnLock);
+    
+    current = iFuseLibGetCurrentTime();
+
+    if(g_InUseShortopConn != NULL) {
+        iFuseLibLog(LOG_DEBUG, "iFuseConnReport: short-op connection (%lu) is in use, last act = %d sec ago, last use = %d sec ago", g_InUseShortopConn->connId, (int)iFuseLibDiffTimeSec(current, g_InUseShortopConn->lastActTime), (int)iFuseLibDiffTimeSec(current, g_InUseShortopConn->lastUseTime));
+        report->inuseShortOpConn++;
+    }
+    
+    for(i=0;i<g_MaxConnNum;i++) {
+        if(g_InUseConn[i] != NULL) {
+            iFuseLibLog(LOG_DEBUG, "iFuseConnReport: general connection (%lu) is in use, last act = %d sec ago, last use = %d sec ago", g_InUseConn[i]->connId, (int)iFuseLibDiffTimeSec(current, g_InUseConn[i]->lastActTime), (int)iFuseLibDiffTimeSec(current, g_InUseConn[i]->lastUseTime));
+            report->inuseConn++;
+        }
+    }
+
+    for(it_connmap=g_InUseOnetimeuseConn.begin();it_connmap!=g_InUseOnetimeuseConn.end();it_connmap++) {
+        iFuseConn = it_connmap->second;
+        
+        iFuseLibLog(LOG_DEBUG, "iFuseConnReport: one-time-use connection (%lu) is in use, last act = %d sec ago, last use = %d sec ago", iFuseConn->connId, (int)iFuseLibDiffTimeSec(current, iFuseConn->lastActTime), (int)iFuseLibDiffTimeSec(current, iFuseConn->lastUseTime));
+        report->inuseOnetimeuseConn++;
+    }
+    
+    if(g_FreeShortopConn != NULL) {
+        iFuseLibLog(LOG_DEBUG, "iFuseConnReport: short-op connection (%lu) is free, last act = %d sec ago, last use = %d sec ago", g_FreeShortopConn->connId, (int)iFuseLibDiffTimeSec(current, g_FreeShortopConn->lastActTime), (int)iFuseLibDiffTimeSec(current, g_FreeShortopConn->lastUseTime));
+        
+        report->freeShortopConn++;
+    }
+    
+    for(it_conn=g_FreeConn.begin();it_conn!=g_FreeConn.end();it_conn++) {
+        iFuseConn = *it_conn;
+        
+        iFuseLibLog(LOG_DEBUG, "iFuseConnReport: connection (%lu) is free, last act = %d sec ago, last use = %d sec ago", iFuseConn->connId, (int)iFuseLibDiffTimeSec(current, iFuseConn->lastActTime), (int)iFuseLibDiffTimeSec(current, iFuseConn->lastUseTime));
+        report->freeConn++;
+    }
+    
+    pthread_rwlock_unlock(&g_ConnectedConnLock);
 }
 
 /*
@@ -423,17 +497,17 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
 
     *iFuseConn = NULL;
 
-    pthread_mutex_lock(&g_ConnectedConnLock);
+    pthread_rwlock_wrlock(&g_ConnectedConnLock);
 
     if(connType == IFUSE_CONN_TYPE_FOR_SHORTOP) {
         if(g_InUseShortopConn != NULL) {
-            pthread_mutex_lock(&g_InUseShortopConn->lock);
-            g_InUseShortopConn->actTime = iFuseLibGetCurrentTime();
+            pthread_rwlock_wrlock(&g_InUseShortopConn->lock);
+            g_InUseShortopConn->lastUseTime = iFuseLibGetCurrentTime();
             g_InUseShortopConn->inuseCnt++;
-            pthread_mutex_unlock(&g_InUseShortopConn->lock);
+            pthread_rwlock_unlock(&g_InUseShortopConn->lock);
 
             *iFuseConn = g_InUseShortopConn;
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return 0;
         }
 
@@ -444,16 +518,16 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
             tmpIFuseConn = g_FreeShortopConn;
             g_FreeShortopConn = NULL;
 
-            pthread_mutex_lock(&tmpIFuseConn->lock);
-            tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+            pthread_rwlock_wrlock(&tmpIFuseConn->lock);
+            tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
             tmpIFuseConn->inuseCnt++;
-            pthread_mutex_unlock(&tmpIFuseConn->lock);
+            pthread_rwlock_unlock(&tmpIFuseConn->lock);
 
             *iFuseConn = tmpIFuseConn;
 
             g_InUseShortopConn = tmpIFuseConn;
 
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return 0;
         }
 
@@ -461,18 +535,18 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
         status = _newConn(&tmpIFuseConn);
         if (status < 0) {
             _freeConn(tmpIFuseConn);
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return status;
         }
 
         tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_SHORTOP;
-        tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+        tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
         tmpIFuseConn->inuseCnt++;
 
         g_InUseShortopConn = tmpIFuseConn;
         *iFuseConn = tmpIFuseConn;
 
-        pthread_mutex_unlock(&g_ConnectedConnLock);
+        pthread_rwlock_unlock(&g_ConnectedConnLock);
         return 0;
     } else if(connType == IFUSE_CONN_TYPE_FOR_FILE_IO) {
         // Decide whether creating a new connection or reuse one of existing connections
@@ -488,35 +562,35 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
             if (!g_FreeConn.empty()) {
                 // reuse existing connection
                 tmpIFuseConn = g_FreeConn.front();
-                pthread_mutex_lock(&tmpIFuseConn->lock);
-                tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+                pthread_rwlock_wrlock(&tmpIFuseConn->lock);
+                tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
                 tmpIFuseConn->inuseCnt++;
-                pthread_mutex_unlock(&tmpIFuseConn->lock);
+                pthread_rwlock_unlock(&tmpIFuseConn->lock);
 
                 *iFuseConn = tmpIFuseConn;
 
                 g_InUseConn[targetIndex] = tmpIFuseConn;
                 g_FreeConn.remove(tmpIFuseConn);
 
-                pthread_mutex_unlock(&g_ConnectedConnLock);
+                pthread_rwlock_unlock(&g_ConnectedConnLock);
                 return 0;
             } else {
                 // create new
                 status = _newConn(&tmpIFuseConn);
                 if (status < 0) {
                     _freeConn(tmpIFuseConn);
-                    pthread_mutex_unlock(&g_ConnectedConnLock);
+                    pthread_rwlock_unlock(&g_ConnectedConnLock);
                     return status;
                 }
 
                 tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_FILE_IO;
-                tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+                tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
                 tmpIFuseConn->inuseCnt++;
 
                 g_InUseConn[targetIndex] = tmpIFuseConn;
                 *iFuseConn = tmpIFuseConn;
 
-                pthread_mutex_unlock(&g_ConnectedConnLock);
+                pthread_rwlock_unlock(&g_ConnectedConnLock);
                 return 0;
             }
         } else {
@@ -539,14 +613,14 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
 
             assert(tmpIFuseConn != NULL);
 
-            pthread_mutex_lock(&tmpIFuseConn->lock);
-            tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+            pthread_rwlock_wrlock(&tmpIFuseConn->lock);
+            tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
             tmpIFuseConn->inuseCnt++;
-            pthread_mutex_unlock(&tmpIFuseConn->lock);
+            pthread_rwlock_unlock(&tmpIFuseConn->lock);
 
             *iFuseConn = tmpIFuseConn;
 
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return 0;
         }
     } else if(connType == IFUSE_CONN_TYPE_FOR_ONETIMEUSE) {
@@ -554,18 +628,18 @@ int iFuseConnGetAndUse(iFuseConn_t **iFuseConn, int connType) {
         status = _newConn(&tmpIFuseConn);
         if (status < 0) {
             _freeConn(tmpIFuseConn);
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return status;
         }
 
         tmpIFuseConn->type = IFUSE_CONN_TYPE_FOR_ONETIMEUSE;
-        tmpIFuseConn->actTime = iFuseLibGetCurrentTime();
+        tmpIFuseConn->lastUseTime = iFuseLibGetCurrentTime();
         tmpIFuseConn->inuseCnt++;
 
         g_InUseOnetimeuseConn[tmpIFuseConn->connId] = tmpIFuseConn;
         *iFuseConn = tmpIFuseConn;
 
-        pthread_mutex_unlock(&g_ConnectedConnLock);
+        pthread_rwlock_unlock(&g_ConnectedConnLock);
         return 0;
     } else {
         assert(0);
@@ -583,10 +657,10 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
 
     assert(iFuseConn != NULL);
 
-    pthread_mutex_lock(&g_ConnectedConnLock);
-    pthread_mutex_lock(&iFuseConn->lock);
+    pthread_rwlock_wrlock(&g_ConnectedConnLock);
+    pthread_rwlock_wrlock(&iFuseConn->lock);
 
-    iFuseConn->actTime = iFuseLibGetCurrentTime();
+    iFuseConn->lastUseTime = iFuseLibGetCurrentTime();
     iFuseConn->inuseCnt--;
 
     assert(iFuseConn->inuseCnt >= 0);
@@ -600,8 +674,8 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
             g_InUseShortopConn = NULL;
             g_FreeShortopConn = iFuseConn;
 
-            pthread_mutex_unlock(&iFuseConn->lock);
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&iFuseConn->lock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return 0;
         } else if(iFuseConn->type == IFUSE_CONN_TYPE_FOR_FILE_IO) {
             for(i=0;i<g_MaxConnNum;i++) {
@@ -611,10 +685,10 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
                 }
             }
 
-            g_FreeConn.push_back(iFuseConn);
+            g_FreeConn.push_front(iFuseConn);
 
-            pthread_mutex_unlock(&iFuseConn->lock);
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&iFuseConn->lock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
             return 0;
         } else if(iFuseConn->type == IFUSE_CONN_TYPE_FOR_ONETIMEUSE) {
             it_connmap = g_InUseOnetimeuseConn.find(iFuseConn->connId);
@@ -623,8 +697,8 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
                 g_InUseOnetimeuseConn.erase(it_connmap);
             }
 
-            pthread_mutex_unlock(&iFuseConn->lock);
-            pthread_mutex_unlock(&g_ConnectedConnLock);
+            pthread_rwlock_unlock(&iFuseConn->lock);
+            pthread_rwlock_unlock(&g_ConnectedConnLock);
 
             _freeConn(iFuseConn);
             return 0;
@@ -633,9 +707,26 @@ int iFuseConnUnuse(iFuseConn_t *iFuseConn) {
         }
     }
 
-    pthread_mutex_unlock(&iFuseConn->lock);
-    pthread_mutex_unlock(&g_ConnectedConnLock);
+    pthread_rwlock_unlock(&iFuseConn->lock);
+    pthread_rwlock_unlock(&g_ConnectedConnLock);
     return 0;
+}
+
+/*
+ * Update last act time
+ */
+void iFuseConnUpdateLastActTime(iFuseConn_t *iFuseConn, bool lock) {
+    assert(iFuseConn != NULL);
+
+    if(lock) {
+        pthread_rwlock_wrlock(&iFuseConn->lock);
+    }
+
+    iFuseConn->lastActTime = iFuseLibGetCurrentTime();
+
+    if(lock) {
+        pthread_rwlock_unlock(&iFuseConn->lock);
+    }
 }
 
 /*
@@ -645,15 +736,17 @@ int iFuseConnReconnect(iFuseConn_t *iFuseConn) {
     int status = 0;
     assert(iFuseConn != NULL);
 
-    pthread_mutex_lock(&iFuseConn->lock);
+    pthread_rwlock_wrlock(&iFuseConn->lock);
 
-    iFuseRodsClientLog(LOG_DEBUG, "iFuseConnReconnect: disconnecting - %lu", iFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "iFuseConnReconnect: disconnecting - %lu", iFuseConn->connId);
     _disconnect(iFuseConn);
 
-    iFuseRodsClientLog(LOG_DEBUG, "iFuseConnReconnect: connecting - %lu", iFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "iFuseConnReconnect: connecting - %lu", iFuseConn->connId);
     status = _connect(iFuseConn);
+    
+    iFuseConn->lastActTime = iFuseLibGetCurrentTime();
 
-    pthread_mutex_unlock(&iFuseConn->lock);
+    pthread_rwlock_unlock(&iFuseConn->lock);
 
     return status;
 }
@@ -664,9 +757,9 @@ int iFuseConnReconnect(iFuseConn_t *iFuseConn) {
 void iFuseConnLock(iFuseConn_t *iFuseConn) {
     assert(iFuseConn != NULL);
 
-    pthread_mutex_lock(&iFuseConn->lock);
+    pthread_rwlock_wrlock(&iFuseConn->lock);
 
-    rodsLog(LOG_DEBUG, "iFuseConnLock: connection locked - %lu", iFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "iFuseConnLock: connection locked - %lu", iFuseConn->connId);
 }
 
 /*
@@ -675,7 +768,7 @@ void iFuseConnLock(iFuseConn_t *iFuseConn) {
 void iFuseConnUnlock(iFuseConn_t *iFuseConn) {
     assert(iFuseConn != NULL);
 
-    pthread_mutex_unlock(&iFuseConn->lock);
+    pthread_rwlock_unlock(&iFuseConn->lock);
 
-    rodsLog(LOG_DEBUG, "iFuseConnUnlock: connection unlocked - %lu", iFuseConn->connId);
+    iFuseLibLog(LOG_DEBUG, "iFuseConnUnlock: connection unlocked - %lu", iFuseConn->connId);
 }

--- a/src/iFuse.Lib.Fd.cpp
+++ b/src/iFuse.Lib.Fd.cpp
@@ -25,8 +25,8 @@ static pthread_mutexattr_t g_AssignedDirLockAttr;
 static pthread_mutex_t g_AssignedDirLock;
 static std::list<iFuseDir_t*> g_AssignedDir;
 
-static unsigned long g_fdIDGen;
-static unsigned long g_ddIDGen;
+static unsigned long g_FdIDGen;
+static unsigned long g_DdIDGen;
 
 /*
  * Lock order : 
@@ -35,11 +35,11 @@ static unsigned long g_ddIDGen;
  */
 
 static unsigned long _genNextFdID() {
-    return g_fdIDGen++;
+    return g_FdIDGen++;
 }
 
 static unsigned long _genNextDdID() {
-    return g_ddIDGen++;
+    return g_DdIDGen++;
 }
 
 static int _closeFd(iFuseFd_t *iFuseFd) {
@@ -219,7 +219,7 @@ void iFuseFdInit() {
     pthread_mutexattr_settype(&g_AssignedFdLockAttr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&g_AssignedFdLock, &g_AssignedFdLockAttr);
     
-    g_fdIDGen = 0;
+    g_FdIDGen = 0;
 }
 
 /*
@@ -230,14 +230,14 @@ void iFuseDirInit() {
     pthread_mutexattr_settype(&g_AssignedDirLockAttr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&g_AssignedDirLock, &g_AssignedDirLockAttr);
     
-    g_ddIDGen = 0;
+    g_DdIDGen = 0;
 }
 
 /*
  * Destroy file descriptor manager
  */
 void iFuseFdDestroy() {
-    g_fdIDGen = 0;
+    g_FdIDGen = 0;
     
     _closeAllFd();
     
@@ -249,7 +249,7 @@ void iFuseFdDestroy() {
  * Destroy directory descriptor manager
  */
 void iFuseDirDestroy() {
-    g_ddIDGen = 0;
+    g_DdIDGen = 0;
     
     _closeAllDir();
     

--- a/src/iFuse.Lib.MetadataCache.cpp
+++ b/src/iFuse.Lib.MetadataCache.cpp
@@ -1,0 +1,748 @@
+/*** Copyright (c), The Regents of the University of California            ***
+ *** For more information please refer to files in the COPYRIGHT directory ***/
+/*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
+ *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <time.h>
+#include <assert.h>
+#include <pthread.h>
+#include <map>
+#include <list>
+#include <string>
+#include <cstring>
+#include "iFuse.Lib.hpp"
+#include "iFuse.Lib.RodsClientAPI.hpp"
+#include "iFuse.Lib.MetadataCache.hpp"
+#include "iFuse.Lib.Util.hpp"
+
+static pthread_mutexattr_t g_StatCacheLockAttr;
+static pthread_mutex_t g_StatCacheLock;
+static pthread_mutexattr_t g_DirCacheLockAttr;
+static pthread_mutex_t g_DirCacheLock;
+
+static std::map<std::string, iFuseStatCache_t*> g_StatCacheMap;
+static std::map<std::string, iFuseDirCache_t*> g_DirCacheMap;
+
+static int g_metadataCacheTimeoutSec = IFUSE_METADATA_CACHE_TIMEOUT_SEC;
+static time_t g_lastStatCacheTimeoutCheck = 0;
+static time_t g_lastDirCacheTimeoutCheck = 0;
+
+static int _newStatCache(iFuseStatCache_t **iFuseStatCache) {
+    iFuseStatCache_t *tmpIFuseStatCache = NULL;
+
+    assert(iFuseStatCache != NULL);
+
+    tmpIFuseStatCache = (iFuseStatCache_t *) calloc(1, sizeof ( iFuseStatCache_t));
+    if(tmpIFuseStatCache == NULL) {
+        *iFuseStatCache = NULL;
+        return SYS_MALLOC_ERR;
+    }
+    
+    tmpIFuseStatCache->timestamp = iFuseLibGetCurrentTime();
+
+    *iFuseStatCache = tmpIFuseStatCache;
+    return 0;
+}
+
+static int _newDirCache(iFuseDirCache_t **iFuseDirCache) {
+    iFuseDirCache_t *tmpIFuseDirCache = NULL;
+
+    assert(iFuseDirCache != NULL);
+
+    tmpIFuseDirCache = (iFuseDirCache_t *) calloc(1, sizeof ( iFuseDirCache_t));
+    if(tmpIFuseDirCache == NULL) {
+        *iFuseDirCache = NULL;
+        return SYS_MALLOC_ERR;
+    }
+    
+    tmpIFuseDirCache->entries = new std::list<char*>();
+    if(tmpIFuseDirCache->entries == NULL) {
+        *iFuseDirCache = NULL;
+        free(tmpIFuseDirCache);
+        return SYS_MALLOC_ERR;
+    }
+    
+    tmpIFuseDirCache->timestamp = iFuseLibGetCurrentTime();
+
+    *iFuseDirCache = tmpIFuseDirCache;
+    return 0;
+}
+
+static int _freeStatCache(iFuseStatCache_t *iFuseStatCache) {
+    assert(iFuseStatCache != NULL);
+
+    if(iFuseStatCache->iRodsPath != NULL) {
+        free(iFuseStatCache->iRodsPath);
+        iFuseStatCache->iRodsPath = NULL;
+    }
+    
+    if(iFuseStatCache->stbuf != NULL) {
+        free(iFuseStatCache->stbuf);
+        iFuseStatCache->stbuf = NULL;
+    }
+    
+    iFuseStatCache->timestamp = 0;
+    free(iFuseStatCache);
+    return 0;
+}
+
+static int _freeDirCache(iFuseDirCache_t *iFuseDirCache) {
+    char *str;
+    
+    assert(iFuseDirCache != NULL);
+
+    if(iFuseDirCache->iRodsPath != NULL) {
+        free(iFuseDirCache->iRodsPath);
+        iFuseDirCache->iRodsPath = NULL;
+    }
+    
+    if(iFuseDirCache->entries != NULL) {
+        while(!iFuseDirCache->entries->empty()) {
+            str = iFuseDirCache->entries->front();
+            iFuseDirCache->entries->pop_front();
+
+            free(str);
+        }
+        
+        delete iFuseDirCache->entries;
+    }
+    
+    iFuseDirCache->timestamp = 0;
+    free(iFuseDirCache);
+    return 0;
+}
+
+static int _cacheStat(const char *iRodsPath, const struct stat *stbuf) {
+    int status = 0;
+    std::map<std::string, iFuseStatCache_t*>::iterator it_statcachemap;
+    iFuseStatCache_t *iFuseStatCache = NULL;
+    iFuseStatCache_t *tmpIFuseStatCache = NULL;
+    
+    assert(iRodsPath != NULL);
+    assert(stbuf != NULL);
+    
+    std::string pathkey(iRodsPath);
+
+    pthread_mutex_lock(&g_StatCacheLock);
+    
+    status = _newStatCache(&iFuseStatCache);
+    if(status != 0) {
+        pthread_mutex_unlock(&g_StatCacheLock);
+        return status;
+    }
+    
+    iFuseStatCache->iRodsPath = strdup(iRodsPath);
+    if(iFuseStatCache->iRodsPath == NULL) {
+        _freeStatCache(iFuseStatCache);
+        pthread_mutex_unlock(&g_StatCacheLock);
+        return SYS_MALLOC_ERR;
+    }
+    
+    iFuseStatCache->stbuf = (struct stat *) calloc(1, sizeof ( struct stat));
+    if(iFuseStatCache->stbuf == NULL) {
+        _freeStatCache(iFuseStatCache);
+        pthread_mutex_unlock(&g_StatCacheLock);
+        return SYS_MALLOC_ERR;
+    }
+    memcpy(iFuseStatCache->stbuf, stbuf, sizeof(struct stat));
+    
+    
+    it_statcachemap = g_StatCacheMap.find(pathkey);
+    if(it_statcachemap != g_StatCacheMap.end()) {
+        tmpIFuseStatCache = it_statcachemap->second;
+        g_StatCacheMap.erase(it_statcachemap);
+        _freeStatCache(tmpIFuseStatCache);
+    }
+    g_StatCacheMap[pathkey] = iFuseStatCache;
+    
+    pthread_mutex_unlock(&g_StatCacheLock);
+    return 0;
+}
+
+static int _cacheDirEntry(const char *iRodsPath, const char *iRodsFilename) {
+    int status = 0;
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+    char *entry_name = NULL;
+    bool create_new = true;
+    
+    assert(iRodsPath != NULL);
+    assert(iRodsFilename != NULL);
+    
+    std::string pathkey(iRodsPath);
+
+    pthread_mutex_lock(&g_DirCacheLock);
+    
+    // check if directory already exists
+    it_dircachemap = g_DirCacheMap.find(pathkey);
+    if(it_dircachemap != g_DirCacheMap.end()) {
+        // has it
+        iFuseDirCache = it_dircachemap->second;
+        if(iFuseDirCache != NULL) {
+            // append
+            create_new = false;
+        } else {
+            g_DirCacheMap.erase(it_dircachemap);
+        }
+    }
+    
+    if(create_new) {
+        status = _newDirCache(&iFuseDirCache);
+        if(status != 0) {
+            pthread_mutex_unlock(&g_DirCacheLock);
+            return status;
+        }
+        
+        iFuseDirCache->iRodsPath = strdup(iRodsPath);
+        if(iFuseDirCache->iRodsPath == NULL) {
+            _freeDirCache(iFuseDirCache);
+            pthread_mutex_unlock(&g_DirCacheLock);
+            return SYS_MALLOC_ERR;
+        }
+        
+        g_DirCacheMap[pathkey] = iFuseDirCache;
+    }
+    
+    if(iFuseDirCache->entries != NULL) {
+        entry_name = strdup(iRodsFilename);
+        if(entry_name == NULL) {
+            pthread_mutex_unlock(&g_DirCacheLock);
+            return SYS_MALLOC_ERR;
+        }
+        
+        iFuseDirCache->entries->push_back(entry_name);
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return 0;
+}
+
+static int _getStatCache(const char *iRodsPath, struct stat *stbuf) {
+    int status = 0;
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseStatCache_t*>::iterator it_statcachemap;
+    iFuseStatCache_t *iFuseStatCache = NULL;
+    
+    assert(iRodsPath != NULL);
+    assert(stbuf != NULL);
+    
+    pthread_mutex_lock(&g_StatCacheLock);
+
+    it_statcachemap = g_StatCacheMap.find(pathkey);
+    if(it_statcachemap != g_StatCacheMap.end()) {
+        // has it
+        iFuseStatCache = it_statcachemap->second;
+        if(iFuseStatCache != NULL) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseStatCache->timestamp) <= g_metadataCacheTimeoutSec) {
+                memcpy(stbuf, iFuseStatCache->stbuf, sizeof(struct stat));
+                status = 0;
+            } else {
+                // expired
+                g_StatCacheMap.erase(it_statcachemap);
+                _freeStatCache(iFuseStatCache);
+                status = -ENOENT;
+            }
+        } else {
+            g_StatCacheMap.erase(it_statcachemap);
+            status = -ENOENT;
+        }
+    } else {
+        status = -ENOENT;
+    }
+    
+    pthread_mutex_unlock(&g_StatCacheLock);
+    return status;
+}
+
+static int _getDirCache(const char *iRodsPath, char **entries, unsigned int *bufferLen) {
+    int status = 0;
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+    std::list<char*>::iterator it_entrylist;
+    int entrybufferlen = 0;
+    char *entrybuffer;
+    char *entrybufferPtr;
+    
+    assert(iRodsPath != NULL);
+    assert(entries != NULL);
+    assert(bufferLen != NULL);
+
+    *entries = NULL;
+    *bufferLen = 0;
+    
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    it_dircachemap = g_DirCacheMap.find(pathkey);
+    if(it_dircachemap != g_DirCacheMap.end()) {
+        // has it
+        iFuseDirCache = it_dircachemap->second;
+        if(iFuseDirCache != NULL) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseDirCache->timestamp) <= g_metadataCacheTimeoutSec) {
+                for(it_entrylist=iFuseDirCache->entries->begin();it_entrylist!=iFuseDirCache->entries->end();it_entrylist++) {
+                    char *entryName = *it_entrylist;
+                    int entryNameLen = strlen(entryName);
+                    entrybufferlen += entryNameLen + 1;
+                }
+                
+                if(entrybufferlen == 0) {
+                    entrybufferlen = 1; // empty null-terminated buffer
+                }
+                
+                entrybuffer = (char *) calloc(1, entrybufferlen);
+                if(entrybuffer == NULL) {
+                    pthread_mutex_unlock(&g_DirCacheLock);
+                    return SYS_MALLOC_ERR;
+                }
+                
+                entrybufferPtr = entrybuffer;
+                for(it_entrylist=iFuseDirCache->entries->begin();it_entrylist!=iFuseDirCache->entries->end();it_entrylist++) {
+                    char *entryName = *it_entrylist;
+                    int entryNameLen = strlen(entryName);
+                    
+                    memcpy(entrybufferPtr, entryName, entryNameLen);
+                    entrybufferPtr += entryNameLen;
+                    *entrybufferPtr = '\0';
+                    entrybufferPtr++;
+                }
+                
+                *entries = entrybuffer;
+                *bufferLen = entrybufferlen;
+                status = 0;
+            } else {
+                // expired
+                g_DirCacheMap.erase(it_dircachemap);
+                _freeDirCache(iFuseDirCache);
+                status = -ENOENT;
+            }
+        } else {
+            g_DirCacheMap.erase(it_dircachemap);
+            status = -ENOENT;
+        }
+    } else {
+       status = -ENOENT;
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return status;
+}
+
+static int _checkFreshessOfDirCache(const char *iRodsPath) {
+    int status = 0;
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+    
+    assert(iRodsPath != NULL);
+    
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    it_dircachemap = g_DirCacheMap.find(pathkey);
+    if(it_dircachemap != g_DirCacheMap.end()) {
+        // has it
+        iFuseDirCache = it_dircachemap->second;
+        if(iFuseDirCache != NULL) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseDirCache->timestamp) <= g_metadataCacheTimeoutSec) {
+                status = 0;
+            } else {
+                // expired
+                g_DirCacheMap.erase(it_dircachemap);
+                _freeDirCache(iFuseDirCache);
+                status = -ENOENT;
+            }
+        } else {
+            g_DirCacheMap.erase(it_dircachemap);
+            status = -ENOENT;
+        }
+    } else {
+       status = -ENOENT;
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return status;
+}
+
+static int _removeStatCache(const char *iRodsPath) {
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseStatCache_t*>::iterator it_statcachemap;
+    iFuseStatCache_t *iFuseStatCache = NULL;
+    
+    assert(iRodsPath != NULL);
+    
+    pthread_mutex_lock(&g_StatCacheLock);
+
+    it_statcachemap = g_StatCacheMap.find(pathkey);
+    if(it_statcachemap != g_StatCacheMap.end()) {
+        // has it
+        iFuseStatCache = it_statcachemap->second;
+        g_StatCacheMap.erase(it_statcachemap);
+       
+        if(iFuseStatCache != NULL) {
+           _freeStatCache(iFuseStatCache);  
+        }
+    }
+    
+    pthread_mutex_unlock(&g_StatCacheLock);
+    return 0;
+}
+
+static int _removeDirCache(const char *iRodsPath) {
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+    
+    assert(iRodsPath != NULL);
+    
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    it_dircachemap = g_DirCacheMap.find(pathkey);
+    if(it_dircachemap != g_DirCacheMap.end()) {
+        // has it
+        iFuseDirCache = it_dircachemap->second;
+        g_DirCacheMap.erase(it_dircachemap);
+       
+        if(iFuseDirCache != NULL) {
+           _freeDirCache(iFuseDirCache);  
+        }
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return 0;
+}
+
+static int _removeDirCacheEntry(const char *iRodsPath, const char *iRodsFilename) {
+    int status = 0;
+    std::string pathkey(iRodsPath);
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+    std::list<char*>::iterator it_entrylist;
+    
+    assert(iRodsPath != NULL);
+    assert(iRodsFilename != NULL);
+    
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    it_dircachemap = g_DirCacheMap.find(pathkey);
+    if(it_dircachemap != g_DirCacheMap.end()) {
+        // has it
+        iFuseDirCache = it_dircachemap->second;
+        if(iFuseDirCache != NULL) {
+            for(it_entrylist=iFuseDirCache->entries->begin();it_entrylist!=iFuseDirCache->entries->end();it_entrylist++) {
+                char *entry = *it_entrylist;
+                if(strcmp(entry, iRodsFilename) == 0) {
+                    iFuseDirCache->entries->erase(it_entrylist);
+                    free(entry);
+                    status = 0;
+                    break;
+                }
+            }
+            status = -ENOENT;
+        } else {
+            g_DirCacheMap.erase(it_dircachemap);
+            status = -ENOENT;
+        }
+    } else {
+        status = -ENOENT;
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return status;
+}
+
+static int _clearExpiredStatCache() {
+    std::map<std::string, iFuseStatCache_t*>::iterator it_statcachemap;
+    std::list<std::string> removeListStatKey;
+    std::list<iFuseStatCache_t*> removeListStatData;
+    iFuseStatCache_t *iFuseStatCache = NULL;
+
+    pthread_mutex_lock(&g_StatCacheLock);
+
+    // release all caches
+    for(it_statcachemap=g_StatCacheMap.begin();it_statcachemap!=g_StatCacheMap.end();it_statcachemap++) {
+        iFuseStatCache = it_statcachemap->second;
+        if(iFuseStatCache != NULL) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseStatCache->timestamp) > g_metadataCacheTimeoutSec) {
+                // expired
+                removeListStatKey.push_back(it_statcachemap->first);
+                removeListStatData.push_back(it_statcachemap->second);
+            }
+        } else {
+           removeListStatKey.push_back(it_statcachemap->first);
+        }
+    }
+
+    while(!removeListStatKey.empty()) {
+        std::string key = removeListStatKey.front();
+        removeListStatKey.pop_front();
+        
+        g_StatCacheMap.erase(key);
+    }
+    
+    while(!removeListStatData.empty()) {
+        iFuseStatCache = removeListStatData.front();
+        removeListStatData.pop_front();
+        
+        _freeStatCache(iFuseStatCache);
+    }
+    
+    pthread_mutex_unlock(&g_StatCacheLock);
+    
+    g_lastStatCacheTimeoutCheck = iFuseLibGetCurrentTime();
+    return 0;
+}
+
+static int _clearExpiredDirCache() {
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    std::list<std::string> removeListDirKey;
+    std::list<iFuseDirCache_t*> removeListDirData;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    // release all caches
+    for(it_dircachemap=g_DirCacheMap.begin();it_dircachemap!=g_DirCacheMap.end();it_dircachemap++) {
+        iFuseDirCache = it_dircachemap->second;
+        if(iFuseDirCache != NULL) {
+            if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), iFuseDirCache->timestamp) > g_metadataCacheTimeoutSec) {
+                // expired
+                removeListDirKey.push_back(it_dircachemap->first);
+                removeListDirData.push_back(it_dircachemap->second);
+            }
+        } else {
+           removeListDirKey.push_back(it_dircachemap->first);
+        }
+    }
+
+    while(!removeListDirKey.empty()) {
+        std::string key = removeListDirKey.front();
+        removeListDirKey.pop_front();
+        
+        g_DirCacheMap.erase(key);
+    }
+    
+    while(!removeListDirData.empty()) {
+        iFuseDirCache = removeListDirData.front();
+        removeListDirData.pop_front();
+        
+        _freeDirCache(iFuseDirCache);
+    }
+    
+    pthread_mutex_unlock(&g_DirCacheLock);
+    return 0;
+}
+
+static int _releaseAllCache() {
+    std::map<std::string, iFuseStatCache_t*>::iterator it_statcachemap;
+    std::map<std::string, iFuseDirCache_t*>::iterator it_dircachemap;
+    iFuseStatCache_t *iFuseStatCache = NULL;
+    iFuseDirCache_t *iFuseDirCache = NULL;
+
+    pthread_mutex_lock(&g_StatCacheLock);
+
+    // release all caches
+    while(!g_StatCacheMap.empty()) {
+        it_statcachemap = g_StatCacheMap.begin();
+        if(it_statcachemap != g_StatCacheMap.end()) {
+            iFuseStatCache = it_statcachemap->second;
+            g_StatCacheMap.erase(it_statcachemap);
+
+            if(iFuseStatCache != NULL) {
+                _freeStatCache(iFuseStatCache);
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&g_StatCacheLock);
+    
+    pthread_mutex_lock(&g_DirCacheLock);
+
+    // release all caches
+    while(!g_DirCacheMap.empty()) {
+        it_dircachemap = g_DirCacheMap.begin();
+        if(it_dircachemap != g_DirCacheMap.end()) {
+            iFuseDirCache = it_dircachemap->second;
+            g_DirCacheMap.erase(it_dircachemap);
+
+            if(iFuseDirCache != NULL) {
+                _freeDirCache(iFuseDirCache);
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&g_DirCacheLock);
+    
+    return 0;
+}
+
+/*
+ * Initialize metadata cache manager
+ */
+void iFuseMetadataCacheInit() {
+    if(iFuseLibGetOption()->metadataCacheTimeoutSec > 0) {
+        g_metadataCacheTimeoutSec = iFuseLibGetOption()->metadataCacheTimeoutSec;
+    }
+    
+    pthread_mutexattr_init(&g_StatCacheLockAttr);
+    pthread_mutexattr_settype(&g_StatCacheLockAttr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&g_StatCacheLock, &g_StatCacheLockAttr);
+    
+    pthread_mutexattr_init(&g_DirCacheLockAttr);
+    pthread_mutexattr_settype(&g_DirCacheLockAttr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(&g_DirCacheLock, &g_DirCacheLockAttr);
+}
+
+/*
+ * Destroy metadata cache manager
+ */
+void iFuseMetadataCacheDestroy() {
+    _releaseAllCache();
+
+    pthread_mutex_destroy(&g_StatCacheLock);
+    pthread_mutexattr_destroy(&g_StatCacheLockAttr);
+    
+    pthread_mutex_destroy(&g_DirCacheLock);
+    pthread_mutexattr_destroy(&g_DirCacheLockAttr);
+}
+
+
+int iFuseMetadataCacheClearExpiredStat(bool force) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredStat");
+    
+    if(!force) {
+        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_lastStatCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
+            return 0;
+        }
+    }
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredStat: Clearing expired stat cache");
+
+    return _clearExpiredStatCache();
+}
+
+int iFuseMetadataCacheClearExpiredDir(bool force) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredDir");
+    
+    if(!force) {
+        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_lastDirCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
+            return 0;
+        }
+    }
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredDir: Clearing expired dir cache");
+
+    return _clearExpiredDirCache();
+}
+
+int iFuseMetadataCachePutStat(const char *iRodsPath, const struct stat *stbuf) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCachePutStat: %s", iRodsPath);
+    
+    return _cacheStat(iRodsPath, stbuf);
+}
+
+int iFuseMetadataCachePutStat2(const char *iRodsDirPath, const char *iRodsFilename, const struct stat *stbuf) {
+    int status;
+    char path[MAX_NAME_LEN];
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCachePutStat2: %s, %s", iRodsDirPath, iRodsFilename);
+    
+    status = iFuseLibJoinPath(iRodsDirPath, iRodsFilename, path, MAX_NAME_LEN);
+    if(status != 0) {
+        return status;
+    }
+    return _cacheStat(path, stbuf);
+}
+
+int iFuseMetadataCacheAddDirEntry(const char *iRodsPath, const char *iRodsFilename) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheAddDirEntry: %s, %s", iRodsPath, iRodsFilename);
+    
+    return _cacheDirEntry(iRodsPath, iRodsFilename);
+}
+
+int iFuseMetadataCacheAddDirEntryIfFresh(const char *iRodsPath, const char *iRodsFilename) {
+    int status;
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheAddDirEntryIfFresh: %s, %s", iRodsPath, iRodsFilename);
+    
+    status = _checkFreshessOfDirCache(iRodsPath);
+    if(status != 0) {
+        return status;
+    }
+    
+    return _cacheDirEntry(iRodsPath, iRodsFilename);
+}
+
+int iFuseMetadataCacheAddDirEntryIfFresh2(const char *iRodsPath) {
+    int status;
+    char myDir[MAX_NAME_LEN];
+    char myEntry[MAX_NAME_LEN];
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheAddDirEntryIfFresh2: %s", iRodsPath);
+
+    status = iFuseLibSplitPath(iRodsPath, myDir, MAX_NAME_LEN, myEntry, MAX_NAME_LEN);
+    if(status != 0) {
+        return status;
+    }
+    
+    status = _checkFreshessOfDirCache(myDir);
+    if(status != 0) {
+        return status;
+    }
+    
+    return _cacheDirEntry(myDir, myEntry);
+}
+
+int iFuseMetadataCacheGetStat(const char *iRodsPath, struct stat *stbuf) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheGetStat: %s", iRodsPath);
+    
+    return _getStatCache(iRodsPath, stbuf);
+}
+
+int iFuseMetadataCacheGetDirEntry(const char *iRodsPath, char **entries, unsigned int *bufferLen) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheGetDirEntry: %s", iRodsPath);
+    
+    return _getDirCache(iRodsPath, entries, bufferLen);
+}
+
+int iFuseMetadataCacheRemoveStat(const char *iRodsPath) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheRemoveStat: %s", iRodsPath);
+    
+    return _removeStatCache(iRodsPath);
+}
+
+int iFuseMetadataCacheRemoveDir(const char *iRodsPath) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheRemoveDir: %s", iRodsPath);
+    
+    return _removeDirCache(iRodsPath);
+}
+
+int iFuseMetadataCacheRemoveDirEntry(const char *iRodsPath, const char *iRodsFilename) {
+    
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheRemoveDirEntry: %s, %s", iRodsPath, iRodsFilename);
+    
+    return _removeDirCacheEntry(iRodsPath, iRodsFilename);
+}
+
+int iFuseMetadataCacheRemoveDirEntry2(const char *iRodsPath) {
+    int status;
+    char myDir[MAX_NAME_LEN];
+    char myEntry[MAX_NAME_LEN];
+
+    iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheRemoveDirEntry2: %s", iRodsPath);
+
+    status = iFuseLibSplitPath(iRodsPath, myDir, MAX_NAME_LEN, myEntry, MAX_NAME_LEN);
+    if(status != 0) {
+        return status;
+    }
+    
+    return _removeDirCacheEntry(myDir, myEntry);
+}

--- a/src/iFuse.Lib.MetadataCache.cpp
+++ b/src/iFuse.Lib.MetadataCache.cpp
@@ -26,8 +26,8 @@ static std::map<std::string, iFuseStatCache_t*> g_StatCacheMap;
 static std::map<std::string, iFuseDirCache_t*> g_DirCacheMap;
 
 static int g_metadataCacheTimeoutSec = IFUSE_METADATA_CACHE_TIMEOUT_SEC;
-static time_t g_lastStatCacheTimeoutCheck = 0;
-static time_t g_lastDirCacheTimeoutCheck = 0;
+static time_t g_LastStatCacheTimeoutCheck = 0;
+static time_t g_LastDirCacheTimeoutCheck = 0;
 
 static int _newStatCache(iFuseStatCache_t **iFuseStatCache) {
     iFuseStatCache_t *tmpIFuseStatCache = NULL;
@@ -489,7 +489,7 @@ static int _clearExpiredStatCache() {
     
     pthread_mutex_unlock(&g_StatCacheLock);
     
-    g_lastStatCacheTimeoutCheck = iFuseLibGetCurrentTime();
+    g_LastStatCacheTimeoutCheck = iFuseLibGetCurrentTime();
     return 0;
 }
 
@@ -606,13 +606,16 @@ void iFuseMetadataCacheDestroy() {
     pthread_mutexattr_destroy(&g_DirCacheLockAttr);
 }
 
+void iFuseMetadataCacheClear() {
+    _releaseAllCache();
+}
 
 int iFuseMetadataCacheClearExpiredStat(bool force) {
     
     iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredStat");
     
     if(!force) {
-        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_lastStatCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
+        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_LastStatCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
             return 0;
         }
     }
@@ -627,7 +630,7 @@ int iFuseMetadataCacheClearExpiredDir(bool force) {
     iFuseRodsClientLog(LOG_DEBUG, "iFuseMetadataCacheClearExpiredDir");
     
     if(!force) {
-        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_lastDirCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
+        if(iFuseLibDiffTimeSec(iFuseLibGetCurrentTime(), g_LastDirCacheTimeoutCheck) <= (g_metadataCacheTimeoutSec / 2)) {
             return 0;
         }
     }

--- a/src/iFuse.Lib.RodsClientAPI.cpp
+++ b/src/iFuse.Lib.RodsClientAPI.cpp
@@ -27,7 +27,7 @@ static std::list<iFuseRodsClientOperation_t*> g_Operations;
 static pthread_t g_TimeoutChecker;
 static bool g_TimeoutCheckerRunning;
 
-static int g_rodsapiTimeoutSec = IFUSE_RODSCLIENTAPI_TIMEOUT_SEC;
+static int g_RodsapiTimeoutSec = IFUSE_RODSCLIENTAPI_TIMEOUT_SEC;
 
 static void* _timeoutChecker(void* param) {
     std::list<iFuseRodsClientOperation_t*>::iterator it_oper;
@@ -48,7 +48,7 @@ static void* _timeoutChecker(void* param) {
         for(it_oper=g_Operations.begin();it_oper!=g_Operations.end();it_oper++) {
             oper = *it_oper;
             
-            if(iFuseLibDiffTimeSec(currentTime, oper->start) >= g_rodsapiTimeoutSec) {
+            if(iFuseLibDiffTimeSec(currentTime, oper->start) >= g_RodsapiTimeoutSec) {
                 removeList.push_back(oper);
             }
         }
@@ -124,7 +124,7 @@ static void _endOperationTimeout(iFuseRodsClientOperation_t *oper) {
 void iFuseRodsClientInit() {
    
     if(iFuseLibGetOption()->rodsapiTimeoutSec > 0) {
-        g_rodsapiTimeoutSec = iFuseLibGetOption()->rodsapiTimeoutSec;
+        g_RodsapiTimeoutSec = iFuseLibGetOption()->rodsapiTimeoutSec;
     }
    
     pthread_mutexattr_init(&g_RodsClientAPILockAttr);

--- a/src/iFuse.Lib.RodsClientAPI.cpp
+++ b/src/iFuse.Lib.RodsClientAPI.cpp
@@ -27,6 +27,8 @@ static std::list<iFuseRodsClientOperation_t*> g_Operations;
 static pthread_t g_TimeoutChecker;
 static bool g_TimeoutCheckerRunning;
 
+static int g_rodsapiTimeoutSec = IFUSE_RODSCLIENTAPI_TIMEOUT_SEC;
+
 static void* _timeoutChecker(void* param) {
     std::list<iFuseRodsClientOperation_t*>::iterator it_oper;
     std::list<iFuseRodsClientOperation_t*> removeList;
@@ -46,7 +48,7 @@ static void* _timeoutChecker(void* param) {
         for(it_oper=g_Operations.begin();it_oper!=g_Operations.end();it_oper++) {
             oper = *it_oper;
             
-            if(IFuseLibDiffTimeSec(currentTime, oper->start) >= IFUSE_RODSCLIENTAPI_TIMEOUT_SEC) {
+            if(iFuseLibDiffTimeSec(currentTime, oper->start) >= g_rodsapiTimeoutSec) {
                 removeList.push_back(oper);
             }
         }
@@ -120,6 +122,11 @@ static void _endOperationTimeout(iFuseRodsClientOperation_t *oper) {
  * Initialize iFuse Rods Client
  */
 void iFuseRodsClientInit() {
+   
+    if(iFuseLibGetOption()->rodsapiTimeoutSec > 0) {
+        g_rodsapiTimeoutSec = iFuseLibGetOption()->rodsapiTimeoutSec;
+    }
+   
     pthread_mutexattr_init(&g_RodsClientAPILockAttr);
     pthread_mutexattr_settype(&g_RodsClientAPILockAttr, PTHREAD_MUTEX_RECURSIVE);
     pthread_mutex_init(&g_RodsClientAPILock, &g_RodsClientAPILockAttr);

--- a/src/iFuse.Lib.cpp
+++ b/src/iFuse.Lib.cpp
@@ -6,6 +6,7 @@
 #include "iFuse.Lib.RodsClientAPI.hpp"
 #include "iFuse.Lib.Conn.hpp"
 #include "iFuse.Lib.Fd.hpp"
+#include "iFuse.Lib.MetadataCache.hpp"
 #include "iFuse.Lib.Util.hpp"
 #include "rodsClient.h"
 
@@ -34,9 +35,13 @@ void iFuseLibInit() {
     
     iFuseFdInit();
     iFuseDirInit();
+    
+    iFuseMetadataCacheInit();
 }
 
 void iFuseLibDestroy() {
+    iFuseMetadataCacheDestroy();
+    
     iFuseDirDestroy();
     iFuseFdDestroy();
     

--- a/src/iFuse.Lib.cpp
+++ b/src/iFuse.Lib.cpp
@@ -2,6 +2,14 @@
  *** For more information please refer to files in the COPYRIGHT directory ***/
 /*** This code is rewritten by Illyoung Choi (iychoi@email.arizona.edu)    ***
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <time.h>
+#include <assert.h>
+#include <pthread.h>
+#include <list>
+#include <unistd.h>
 #include "iFuse.Lib.hpp"
 #include "iFuse.Lib.RodsClientAPI.hpp"
 #include "iFuse.Lib.Conn.hpp"
@@ -12,6 +20,46 @@
 
 static rodsEnv g_iFuseEnv;
 static iFuseOpt_t g_iFuseOpt;
+
+static pthread_rwlock_t g_TimerHandlerLock;
+static pthread_rwlockattr_t g_TimerHandlerLockAttr;
+static std::list<iFuseLibTimerHandlerCB> g_TimerHandlers;
+
+static pthread_t g_Timer;
+static bool g_TimerRunning;
+
+static void* _timerTick(void* param) {
+    std::list<iFuseLibTimerHandlerCB>::iterator it_cb;
+    iFuseLibTimerHandlerCB callback;
+    
+    UNUSED(param);
+    
+    iFuseLibLog(LOG_DEBUG, "_timerTick: timer is running");
+    
+    while(g_TimerRunning) {
+        //iFuseLibLog(LOG_DEBUG, "_timerTick: calling timer handlers");
+        
+        pthread_rwlock_rdlock(&g_TimerHandlerLock);
+
+        // iterate list
+        for(it_cb=g_TimerHandlers.begin();it_cb!=g_TimerHandlers.end();it_cb++) {
+            callback = *it_cb;
+        
+            //iFuseLibLog(LOG_DEBUG, "_timerTick: calling a timer handler %p", callback);
+            callback();
+        }
+        
+        pthread_rwlock_unlock(&g_TimerHandlerLock);
+        
+        //iFuseLibLog(LOG_DEBUG, "_timerTick: called all timer handlers, sleep 1sec");
+        
+        usleep(1000);
+    }
+    
+    iFuseLibLog(LOG_DEBUG, "_timerTick: timer is stopped");
+    
+    return NULL;
+}
 
 rodsEnv *iFuseLibGetRodsEnv() {
     return &g_iFuseEnv;
@@ -30,11 +78,16 @@ void iFuseLibSetOption(iFuseOpt_t *pOpt) {
 }
 
 void iFuseLibInit() {
+    // timer
+    pthread_rwlockattr_init(&g_TimerHandlerLockAttr);
+    pthread_rwlock_init(&g_TimerHandlerLock, &g_TimerHandlerLockAttr);
+    
+    iFuseUtilInit();
+    
     iFuseRodsClientInit();
     iFuseConnInit();
     
     iFuseFdInit();
-    iFuseDirInit();
     
     iFuseMetadataCacheInit();
 }
@@ -42,9 +95,40 @@ void iFuseLibInit() {
 void iFuseLibDestroy() {
     iFuseMetadataCacheDestroy();
     
-    iFuseDirDestroy();
     iFuseFdDestroy();
     
     iFuseConnDestroy();
     iFuseRodsClientDestroy();
+    
+    iFuseUtilDestroy();
+    
+    pthread_rwlock_destroy(&g_TimerHandlerLock);
+    pthread_rwlockattr_destroy(&g_TimerHandlerLockAttr);
+}
+
+void iFuseLibInitTimerThread() {
+    // should be called in FUSE_INIT to avoid dead-lock issue in FUSE
+    g_TimerRunning = true;
+    pthread_create(&g_Timer, NULL, _timerTick, NULL);
+}
+
+void iFuseLibTerminateTimerThread() {
+    g_TimerRunning = false;
+    pthread_join(g_Timer, NULL);    
+}
+
+void iFuseLibSetTimerTickHandler(iFuseLibTimerHandlerCB callback) {
+    pthread_rwlock_wrlock(&g_TimerHandlerLock);
+    
+    g_TimerHandlers.push_back(callback);
+    
+    pthread_rwlock_unlock(&g_TimerHandlerLock);
+}
+
+void iFuseLibUnsetTimerTickHandler(iFuseLibTimerHandlerCB callback) {
+    pthread_rwlock_wrlock(&g_TimerHandlerLock);
+    
+    g_TimerHandlers.remove(callback);
+    
+    pthread_rwlock_unlock(&g_TimerHandlerLock);
 }

--- a/src/iFuseCmdLineOpt.cpp
+++ b/src/iFuseCmdLineOpt.cpp
@@ -15,12 +15,24 @@
 #include "iFuse.Lib.Conn.hpp"
 #include "iFuse.Lib.MetadataCache.hpp"
 #include "iFuse.Lib.RodsClientAPI.hpp"
+#include "iFuse.Lib.Util.hpp"
 #include "iFuse.Preload.hpp"
 #include "miscUtil.h"
 
 static iFuseOpt_t g_Opt;
 
+static bool _atob(const char *str) {
+    if(str == NULL) {
+        return false;
+    } else if(iFuseUtilStricmp(str, "true") == 0) {
+        return true;
+    }
+    return false;
+}
+
 void iFuseCmdOptsInit() {
+    char *value;
+    
     bzero(&g_Opt, sizeof(iFuseOpt_t));
 
     g_Opt.bufferedFS = true;
@@ -35,6 +47,69 @@ void iFuseCmdOptsInit() {
     g_Opt.rodsapiTimeoutSec = IFUSE_RODSCLIENTAPI_TIMEOUT_SEC;
     g_Opt.preloadNumBlocks = IFUSE_PRELOAD_PBLOCK_NUM;
     g_Opt.metadataCacheTimeoutSec = IFUSE_METADATA_CACHE_TIMEOUT_SEC;
+    
+    // check environmental variables
+    value = getenv("IRODSFS_NOCACHE"); // true/false
+    if(_atob(value)) {
+        g_Opt.bufferedFS = false;
+        g_Opt.preload = false;
+        g_Opt.cacheMetadata = false;
+    }
+    
+    value = getenv("IRODSFS_NOPRELOAD"); // true/false
+    if(_atob(value)) {
+        g_Opt.preload = false;
+    }
+    
+    value = getenv("IRODSFS_NOCACHEMETADATA"); // true/false
+    if(_atob(value)) {
+        g_Opt.cacheMetadata = false;
+    }
+    
+    value = getenv("IRODSFS_MAXCONN"); // number
+    if(value != NULL) {
+        g_Opt.maxConn = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_BLOCKSIZE"); // number
+    if(value != NULL) {
+        g_Opt.blocksize = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_CONNREUSE"); // true/false
+    if(_atob(value)) {
+        g_Opt.connReuse = true;
+    }
+    
+    value = getenv("IRODSFS_CONNTIMEOUT"); // number
+    if(value != NULL) {
+        g_Opt.connTimeoutSec = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_CONNKEEPALIVE"); // number
+    if(value != NULL) {
+        g_Opt.connKeepAliveSec = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_CONNCHECKINTERVAL"); // number
+    if(value != NULL) {
+        g_Opt.connCheckIntervalSec = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_APITIMEOUT"); // number
+    if(value != NULL) {
+        g_Opt.rodsapiTimeoutSec = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_PRELOADBLOCKS"); // number
+    if(value != NULL) {
+        g_Opt.preloadNumBlocks = atoi(value);
+    }
+    
+    value = getenv("IRODSFS_METADATACACHETIMEOUT"); // number
+    if(value != NULL) {
+        g_Opt.metadataCacheTimeoutSec = atoi(value);
+    }
 }
 
 void iFuseCmdOptsDestroy() {

--- a/src/iFuseCmdLineOpt.cpp
+++ b/src/iFuseCmdLineOpt.cpp
@@ -83,7 +83,10 @@ void iFuseCmdOptsParse(int argc, char **argv) {
     g_Opt.program = strdup(argv[0]);
 
     for(i=0;i<argc;i++) {
-        if(strcmp("-onocache", argv[i]) == 0) {
+        if(strcmp("--version", argv[i]) == 0) {
+            g_Opt.version = true;
+            argv[i] = "-Z";
+        } else if(strcmp("-onocache", argv[i]) == 0) {
             g_Opt.bufferedFS = false;
             g_Opt.preload = false;
             g_Opt.cacheMetadata = false;
@@ -149,8 +152,20 @@ void iFuseCmdOptsParse(int argc, char **argv) {
     }
 
     optind = 1;
-    while((c = getopt(argc, argv, "dfo:Z")) != -1) {
+    while((c = getopt(argc, argv, "hvVdfo:Z")) != -1) {
         switch(c) {
+            case 'h':
+                {
+                    // help
+                    g_Opt.help = true;
+                }
+                break;
+            case 'v':
+            case 'V':
+                {
+                    g_Opt.version = true;
+                }
+                break;
             case 'd':
                 {
                     // fuse debug mode
@@ -193,9 +208,10 @@ void iFuseCmdOptsParse(int argc, char **argv) {
     }
 
     for(index=optind;index<argc;index++) {
-        assert(g_Opt.mountpoint == NULL);
-
-        g_Opt.mountpoint = strdup(argv[index]);
+        if(argv[index] != NULL && strlen(argv[index]) > 0) {
+            g_Opt.mountpoint = strdup(argv[index]);
+            break;
+        }
     }
 }
 

--- a/src/iFuseCmdLineOpt.cpp
+++ b/src/iFuseCmdLineOpt.cpp
@@ -122,6 +122,11 @@ void iFuseCmdOptsParse(int argc, char **argv) {
                         fprintf(stderr, "use_ino fuse option not supported, ignoring\n");
                         break;
                     }
+                    if (!strcmp("nonempty", optarg)) {
+                        // fuse nonempty option
+                        g_Opt.nonempty = true;
+                        break;
+                    }
                     bzero(buff, MAX_NAME_LEN);
                     sprintf(buff, "-o%s", optarg);
                     iFuseCmdOptsAdd(buff);
@@ -230,6 +235,15 @@ void iFuseGenCmdLineForFuse(int *fuse_argc, char ***fuse_argv) {
 
         if(g_Opt.debug) {
             fprintf(stdout, "foreground : %d\n", g_Opt.foreground);
+        }
+    }
+    
+    if(g_Opt.nonempty) {
+        argv[i] = strdup("-nonempty");
+        i++;
+
+        if(g_Opt.debug) {
+            fprintf(stdout, "nonempty : %d\n", g_Opt.nonempty);
         }
     }
 

--- a/src/iFuseCmdLineOpt.cpp
+++ b/src/iFuseCmdLineOpt.cpp
@@ -11,7 +11,11 @@
 #include <ctype.h>
 #include <unistd.h>
 #include "iFuseCmdLineOpt.hpp"
+#include "iFuse.FS.hpp"
 #include "iFuse.Lib.Conn.hpp"
+#include "iFuse.Lib.MetadataCache.hpp"
+#include "iFuse.Lib.RodsClientAPI.hpp"
+#include "iFuse.Preload.hpp"
 #include "miscUtil.h"
 
 static iFuseOpt_t g_Opt;
@@ -21,9 +25,16 @@ void iFuseCmdOptsInit() {
 
     g_Opt.bufferedFS = true;
     g_Opt.preload = true;
+    g_Opt.cacheMetadata = true;
     g_Opt.maxConn = IFUSE_MAX_NUM_CONN;
+    g_Opt.blocksize = IFUSE_BUFFER_CACHE_BLOCK_SIZE;
+    g_Opt.connReuse = false;
     g_Opt.connTimeoutSec = IFUSE_FREE_CONN_TIMEOUT_SEC;
     g_Opt.connKeepAliveSec = IFUSE_FREE_CONN_KEEPALIVE_SEC;
+    g_Opt.connCheckIntervalSec = IFUSE_FREE_CONN_CHECK_INTERVAL_SEC;
+    g_Opt.rodsapiTimeoutSec = IFUSE_RODSCLIENTAPI_TIMEOUT_SEC;
+    g_Opt.preloadNumBlocks = IFUSE_PRELOAD_PBLOCK_NUM;
+    g_Opt.metadataCacheTimeoutSec = IFUSE_METADATA_CACHE_TIMEOUT_SEC;
 }
 
 void iFuseCmdOptsDestroy() {
@@ -75,15 +86,28 @@ void iFuseCmdOptsParse(int argc, char **argv) {
         if(strcmp("-onocache", argv[i]) == 0) {
             g_Opt.bufferedFS = false;
             g_Opt.preload = false;
+            g_Opt.cacheMetadata = false;
             argv[i] = "-Z";
         } else if(strcmp("-onopreload", argv[i]) == 0) {
             g_Opt.preload = false;
+            argv[i] = "-Z";
+        } else if(strcmp("-onocachemetadata", argv[i]) == 0) {
+            g_Opt.cacheMetadata = false;
             argv[i] = "-Z";
         } else if(strcmp("-omaxconn", argv[i]) == 0) {
             if(argc > i+1) {
                 g_Opt.maxConn = atoi(argv[i+1]);
                 argv[i+1] = "-Z";
             }
+            argv[i] = "-Z";
+        } else if(strcmp("-oblocksize", argv[i]) == 0) {
+            if(argc > i+1) {
+                g_Opt.blocksize = atoi(argv[i+1]);
+                argv[i+1] = "-Z";
+            }
+            argv[i] = "-Z";
+        } else if(strcmp("-oconnreuse", argv[i]) == 0) {
+            g_Opt.connReuse = true;
             argv[i] = "-Z";
         } else if(strcmp("-oconntimeout", argv[i]) == 0) {
             if(argc > i+1) {
@@ -94,6 +118,30 @@ void iFuseCmdOptsParse(int argc, char **argv) {
         } else if(strcmp("-oconnkeepalive", argv[i]) == 0) {
             if(argc > i+1) {
                 g_Opt.connKeepAliveSec = atoi(argv[i+1]);
+                argv[i+1] = "-Z";
+            }
+            argv[i] = "-Z";
+        } else if(strcmp("-oconncheckinterval", argv[i]) == 0) {
+            if(argc > i+1) {
+                g_Opt.connCheckIntervalSec = atoi(argv[i+1]);
+                argv[i+1] = "-Z";
+            }
+            argv[i] = "-Z";
+        } else if(strcmp("-oapitimeout", argv[i]) == 0) {
+            if(argc > i+1) {
+                g_Opt.rodsapiTimeoutSec = atoi(argv[i+1]);
+                argv[i+1] = "-Z";
+            }
+            argv[i] = "-Z";
+        } else if(strcmp("-opreloadblocks", argv[i]) == 0) {
+            if(argc > i+1) {
+                g_Opt.preloadNumBlocks = atoi(argv[i+1]);
+                argv[i+1] = "-Z";
+            }
+            argv[i] = "-Z";
+        } else if(strcmp("-ometadatacachetimeout", argv[i]) == 0) {
+            if(argc > i+1) {
+                g_Opt.metadataCacheTimeoutSec = atoi(argv[i+1]);
                 argv[i+1] = "-Z";
             }
             argv[i] = "-Z";

--- a/src/iFuseOper.cpp
+++ b/src/iFuseOper.cpp
@@ -11,6 +11,7 @@
 #include "iFuse.Preload.hpp"
 #include "iFuse.BufferedFS.hpp"
 #include "iFuse.FS.hpp"
+#include "iFuse.Lib.hpp"
 #include "iFuse.Lib.Fd.hpp"
 #include "iFuse.Lib.Conn.hpp"
 #include "iFuse.Lib.Util.hpp"
@@ -465,8 +466,6 @@ int iFuseReadDir(const char *path, void *buf, fuse_fill_dir_t filler, off_t offs
     assert(fi->fh != 0);
     
     iFuseDir = (iFuseDir_t *)fi->fh;
-    
-    assert(iFuseDir->handle != NULL);
     
     bzero(iRodsPath, MAX_NAME_LEN);
     status = iFuseRodsClientMakeRodsPath(path, iRodsPath);

--- a/src/iFuseOper.cpp
+++ b/src/iFuseOper.cpp
@@ -19,22 +19,21 @@
 #include "sockComm.h"
 
 void *iFuseInit(struct fuse_conn_info *conn) {
-    UNUSED(conn);
+    if (conn->capable & FUSE_CAP_BIG_WRITES) {
+        conn->want |= FUSE_CAP_BIG_WRITES;
+    }
     
-    iFuseLibInit();
-    iFuseFsInit();
-    iFuseBufferedFSInit();
-    iFusePreloadInit();
+#ifdef FUSE_CAP_IOCTL_DIR    
+    if (conn->capable & FUSE_CAP_IOCTL_DIR) {
+        conn->want |= FUSE_CAP_IOCTL_DIR;
+    }
+#endif
+
     return NULL;
 }
 
 void iFuseDestroy(void *data) {
     UNUSED(data);
-    
-    iFusePreloadDestroy();
-    iFuseBufferedFSDestroy();
-    iFuseFsDestroy();
-    iFuseLibDestroy();
 }
 
 int iFuseGetAttr(const char *path, struct stat *stbuf) {
@@ -753,6 +752,29 @@ int iFuseChown(const char *path, uid_t uid, gid_t gid) {
 int iFuseUtimens(const char *path, const struct timespec ts[2]) {
     UNUSED(path);
     UNUSED(ts);
+    
+    return 0;
+}
+
+int iFuseIoctl(const char *path, int cmd, void *arg, struct fuse_file_info *fi, unsigned int flags, void *data) {
+    int status = 0;
+    char iRodsPath[MAX_NAME_LEN];
+    
+    bzero(iRodsPath, MAX_NAME_LEN);
+    status = iFuseRodsClientMakeRodsPath(path, iRodsPath);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status,
+                "iFuseIoctl: iFuseRodsClientMakeRodsPath of %s error", path);
+        // use ENOTDIR for this type of error
+        return -ENOTDIR;
+    }
+    
+    status = iFuseFsIoctl(iRodsPath, cmd, arg, fi, flags, data);
+    if (status < 0) {
+        iFuseRodsClientLogError(LOG_ERROR, status, 
+                "iFuseIoctl: cannot peform ioctl of a file for %s error", iRodsPath);
+        return status;
+    }
     
     return 0;
 }

--- a/src/irodsFs.cpp
+++ b/src/irodsFs.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     // check mount point
     status = checkMountPoint(myiFuseOpt.mountpoint, myiFuseOpt.nonempty);
     if(status != 0) {
-        fprintf(stderr, "iRods Fuse abort: mount point is not empty\n");
+        fprintf(stderr, "iRods Fuse abort: mount point check failed\n");
         iFuseCmdOptsDestroy();
         return 1;
     }

--- a/src/irodsFs.cpp
+++ b/src/irodsFs.cpp
@@ -4,6 +4,7 @@
  *** funded by iPlantCollaborative (www.iplantcollaborative.org).          ***/
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
 #include <errno.h>
 #include <time.h>
 #include <assert.h>
@@ -11,6 +12,7 @@
 #include "rodsClient.h"
 #include "parseCommandLine.h"
 #include "iFuse.Lib.hpp"
+#include "iFuse.Lib.Conn.hpp"
 #include "iFuseOper.hpp"
 #include "iFuse.Lib.RodsClientAPI.hpp"
 #include "iFuseCmdLineOpt.hpp"
@@ -18,6 +20,7 @@
 static struct fuse_operations irodsOper;
 
 static void usage();
+static int checkMountPoint(char *mountPoint, bool nonempty);
 
 int main(int argc, char **argv) {
     int status;
@@ -74,7 +77,7 @@ int main(int argc, char **argv) {
 
     status = getRodsEnv(&myRodsEnv);
     if (status < 0) {
-        iFuseRodsClientLogError(LOG_ERROR, status, "main: getRodsEnv error. ");
+        iFuseRodsClientLogError(LOG_ERROR, status, "main: getRodsEnv error.");
         return 1;
     }
 
@@ -84,11 +87,28 @@ int main(int argc, char **argv) {
     iFuseCmdOptsAdd("-odirect_io");
 
     iFuseGetOption(&myiFuseOpt);
+    
+    // check mount point
+    status = checkMountPoint(myiFuseOpt.mountpoint, myiFuseOpt.nonempty);
+    if(status != 0) {
+        fprintf(stderr, "iRods Fuse abort: mount point is not empty\n");
+        iFuseCmdOptsDestroy();
+        return 1;
+    }
 
     iFuseLibSetRodsEnv(&myRodsEnv);
     iFuseLibSetOption(&myiFuseOpt);
 
+    // check iRODS iCAT host connectivity
+    status = iFuseConnTest();
+    if(status != 0) {
+        fprintf(stderr, "iRods Fuse abort: cannot connect to iCAT\n");
+        iFuseCmdOptsDestroy();
+        return 1;
+    }
+    
     iFuseGenCmdLineForFuse(&fuse_argc, &fuse_argv);
+    
     iFuseRodsClientLog(LOG_DEBUG, "main: iRods Fuse gets started.");
     status = fuse_main(fuse_argc, fuse_argv, &irodsOper, NULL);
     iFuseReleaseCmdLineForFuse(fuse_argc, fuse_argv);
@@ -96,7 +116,7 @@ int main(int argc, char **argv) {
     iFuseCmdOptsDestroy();
 
     if (status < 0) {
-        return 3;
+        return 1;
     } else {
         return 0;
     }
@@ -120,4 +140,73 @@ static void usage() {
         }
         printf("%s\n", msgs[i]);
     }
+}
+
+static int checkMountPoint(char *mountPoint, bool nonempty) {
+    DIR *dir = NULL;
+    char cwd[MAX_NAME_LEN];
+    char mpath[MAX_NAME_LEN];
+    char mpathabs[MAX_NAME_LEN];
+
+    if(mountPoint == NULL || strlen(mountPoint) == 0) {
+        fprintf(stderr, "Mount point is not given\n");
+        return -1;
+    }
+    
+    if(getcwd(cwd, sizeof(cwd)) != NULL) {
+        if(mountPoint[0] == '/') {
+            strcpy(mpath, mountPoint);
+        } else {
+            strcpy(mpath, cwd);
+            if(mpath[strlen(mpath)-1] != '/') {
+                strcat(mpath, "/");
+            }
+            strcat(mpath, mountPoint);
+        }
+    } else {
+        fprintf(stderr, "Cannot get a current directory\n");
+        return -1;
+    }
+    
+    realpath(mpath, mpathabs);
+    if(mpathabs[strlen(mpathabs)-1] != '/') {
+        strcat(mpathabs, "/");
+    }
+    
+    dir = opendir(mpathabs);
+    if(dir != NULL) {
+        // exists
+        bool filefound = false;
+        if(!nonempty) {
+            // check if directory is empty or not
+            struct dirent *d;
+            while ((d = readdir(dir)) != NULL) {
+                if(!strcmp(d->d_name, ".")) {
+                    continue;
+                } else if(!strcmp(d->d_name, "..")) {
+                    continue;
+                } else {
+                    filefound = true;
+                    break;
+                }
+            }
+        }
+        
+        closedir(dir);
+        
+        if(filefound) {
+            fprintf(stderr, "A directory %s is not empty\nif you are sure this is safe, use the 'nonempty' mount option", mpathabs);
+            return -1;
+        }
+    } else if(errno == ENOENT) {
+        // directory not accessible
+        fprintf(stderr, "Cannot find a directory %s\n", mpathabs);
+        return -1;
+    } else {
+        // not accessible
+        fprintf(stderr, "The directory %s is not accessible\n", mpathabs);
+        return -1;
+    }
+    
+    return 0;
 }


### PR DESCRIPTION
Implement metadata cache
- Cache stat of a file/directory
- Cache directory entries
- Few minor performance optimizations related to metadata cache
- Make hard-coded parameters configurable via command-line options
- Refactor code